### PR TITLE
fix: Override types of timestamp columns to avoid `time` conflict

### DIFF
--- a/pgmq-rs/.sqlx/query-4f4d42f44b0731d55ed5cbcd391fdda0f900b95c9ceacc2356d27e746ba7fb62.json
+++ b/pgmq-rs/.sqlx/query-4f4d42f44b0731d55ed5cbcd391fdda0f900b95c9ceacc2356d27e746ba7fb62.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * from pgmq.set_vt(queue_name=>$1::text, msg_id=>$2::bigint, vt=>$3::integer);",
+  "query": "SELECT msg_id, read_ct, enqueued_at as \"enqueued_at: chrono::DateTime<Utc>\", vt as \"vt: chrono::DateTime<Utc>\", message from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)",
   "describe": {
     "columns": [
       {
@@ -15,29 +15,24 @@
       },
       {
         "ordinal": 2,
-        "name": "enqueued_at",
+        "name": "enqueued_at: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 3,
-        "name": "vt",
+        "name": "vt: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 4,
         "name": "message",
         "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 5,
-        "name": "headers",
-        "type_info": "Jsonb"
       }
     ],
     "parameters": {
       "Left": [
         "Text",
-        "Int8",
+        "Int4",
         "Int4"
       ]
     },
@@ -46,9 +41,8 @@
       null,
       null,
       null,
-      null,
       null
     ]
   },
-  "hash": "b60d35a08c8f6a1f449eb95d019b96aef002d56257427965b0205591cee50b9b"
+  "hash": "4f4d42f44b0731d55ed5cbcd391fdda0f900b95c9ceacc2356d27e746ba7fb62"
 }

--- a/pgmq-rs/.sqlx/query-b46b05578c075ecc8fb9c561a6d0be974810f4c2047b388832ef14f20a61996c.json
+++ b/pgmq-rs/.sqlx/query-b46b05578c075ecc8fb9c561a6d0be974810f4c2047b388832ef14f20a61996c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * from pgmq.list_queues();",
+  "query": "SELECT queue_name, is_partitioned, is_unlogged, created_at as \"created_at: chrono::DateTime<Utc>\" from pgmq.list_queues();",
   "describe": {
     "columns": [
       {
@@ -20,7 +20,7 @@
       },
       {
         "ordinal": 3,
-        "name": "created_at",
+        "name": "created_at: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       }
     ],
@@ -34,5 +34,5 @@
       null
     ]
   },
-  "hash": "ecde748537ee27524a682a71ac5bfd9237c8b44300c6809cc5808cc1ba497d60"
+  "hash": "b46b05578c075ecc8fb9c561a6d0be974810f4c2047b388832ef14f20a61996c"
 }

--- a/pgmq-rs/.sqlx/query-de9ca57e75bfddcf8516ee5f7e65a0e5a1c90ccf1984d6f5d30cb27f9a282c45.json
+++ b/pgmq-rs/.sqlx/query-de9ca57e75bfddcf8516ee5f7e65a0e5a1c90ccf1984d6f5d30cb27f9a282c45.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * from pgmq.read_with_poll(\n                queue_name=>$1::text,\n                vt=>$2::integer,\n                qty=>$3::integer,\n                max_poll_seconds=>$4::integer,\n                poll_interval_ms=>$5::integer\n            )",
+  "query": "SELECT msg_id, read_ct, enqueued_at as \"enqueued_at: chrono::DateTime<Utc>\", vt as \"vt: chrono::DateTime<Utc>\", message from pgmq.read_with_poll(\n                queue_name=>$1::text,\n                vt=>$2::integer,\n                qty=>$3::integer,\n                max_poll_seconds=>$4::integer,\n                poll_interval_ms=>$5::integer\n            )",
   "describe": {
     "columns": [
       {
@@ -15,22 +15,17 @@
       },
       {
         "ordinal": 2,
-        "name": "enqueued_at",
+        "name": "enqueued_at: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 3,
-        "name": "vt",
+        "name": "vt: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 4,
         "name": "message",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 5,
-        "name": "headers",
         "type_info": "Jsonb"
       }
     ],
@@ -48,9 +43,8 @@
       null,
       null,
       null,
-      null,
       null
     ]
   },
-  "hash": "20f1319da349f2ade7036aa4ceb29784f0244bd2fc6b48f1ed1026130257da3e"
+  "hash": "de9ca57e75bfddcf8516ee5f7e65a0e5a1c90ccf1984d6f5d30cb27f9a282c45"
 }

--- a/pgmq-rs/.sqlx/query-e4ae7d7a07b82942bedfd633a555e7eeca38781a82d78096a9a388f74d42e96e.json
+++ b/pgmq-rs/.sqlx/query-e4ae7d7a07b82942bedfd633a555e7eeca38781a82d78096a9a388f74d42e96e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)",
+  "query": "SELECT msg_id, read_ct, enqueued_at as \"enqueued_at: chrono::DateTime<Utc>\", vt as \"vt: chrono::DateTime<Utc>\", message from pgmq.set_vt(queue_name=>$1::text, msg_id=>$2::bigint, vt=>$3::integer);",
   "describe": {
     "columns": [
       {
@@ -15,29 +15,24 @@
       },
       {
         "ordinal": 2,
-        "name": "enqueued_at",
+        "name": "enqueued_at: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 3,
-        "name": "vt",
+        "name": "vt: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 4,
         "name": "message",
         "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 5,
-        "name": "headers",
-        "type_info": "Jsonb"
       }
     ],
     "parameters": {
       "Left": [
         "Text",
-        "Int4",
+        "Int8",
         "Int4"
       ]
     },
@@ -46,9 +41,8 @@
       null,
       null,
       null,
-      null,
       null
     ]
   },
-  "hash": "21b0ca154a192498417a9f1683193f1103d1d6fa4d9dfdc195fb6b8c8092e602"
+  "hash": "e4ae7d7a07b82942bedfd633a555e7eeca38781a82d78096a9a388f74d42e96e"
 }

--- a/pgmq-rs/.sqlx/query-f9b9885aac1d19e2a06b147d3a4f9a4f7a43c1d27be38adfb188aa4b7805b80d.json
+++ b/pgmq-rs/.sqlx/query-f9b9885aac1d19e2a06b147d3a4f9a4f7a43c1d27be38adfb188aa4b7805b80d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * from pgmq.pop(queue_name=>$1::text)",
+  "query": "SELECT msg_id, read_ct, enqueued_at as \"enqueued_at: chrono::DateTime<Utc>\", vt as \"vt: chrono::DateTime<Utc>\", message from pgmq.pop(queue_name=>$1::text)",
   "describe": {
     "columns": [
       {
@@ -15,22 +15,17 @@
       },
       {
         "ordinal": 2,
-        "name": "enqueued_at",
+        "name": "enqueued_at: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 3,
-        "name": "vt",
+        "name": "vt: chrono::DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 4,
         "name": "message",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 5,
-        "name": "headers",
         "type_info": "Jsonb"
       }
     ],
@@ -44,9 +39,8 @@
       null,
       null,
       null,
-      null,
       null
     ]
   },
-  "hash": "3ef45ff6a19824d8ee74cee7c59d61842adf0c5a619b1ac3acd47c448683e8e1"
+  "hash": "f9b9885aac1d19e2a06b147d3a4f9a4f7a43c1d27be38adfb188aa4b7805b80d"
 }

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 repository = "https://github.com/tembo-io/pgmq"
 
 [dependencies]
-chrono = { version = "0.4.23", features = [ "serde" ] }
+chrono = { version = "0.4.23", features = ["serde"] }
 serde = { version = "1.0.152" }
-serde_json = { version = "1.0.91", features = [ "raw_value" ] }
-sqlx = { version = "0.8.1", features = [ "runtime-tokio" , "postgres", "chrono", "json" ] }
+serde_json = { version = "1.0.91", features = ["raw_value"] }
+sqlx = { version = "0.8.1", features = ["runtime-tokio", "postgres", "chrono", "json"] }
 thiserror = "1.0.38"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.17"
@@ -29,7 +29,15 @@ env_logger = "0.10.0"
 rand = "0.8.5"
 regex = "1.5.4"
 lazy_static = "1.4.0"
-# Enable the `time` feature in dev dependencies to ensure we are able to support consumers who have
-# the feature enabled, either directly or via a transitive dependency. See the following issue for
-# more details: https://github.com/launchbadge/sqlx/issues/3412
+
+# If a consumer has both the `time` and `chrono` features of `sqlx` enabled, `sqlx` will default to using
+# `OffsetDateTime` (from `time`) for timestamp fields instead of `DateTime<Utc>` (from `chrono`), causing a compilation
+# error in `pgmq`. See this issue for more details: https://github.com/launchbadge/sqlx/issues/3412
+
+# `pgmq` only uses the `chrono` feature of `sqlx`, so it's possible to add a query that would encounter this conflict
+# in a consumer and not notice because `pgmq` compiles fine on its own. To ensure queries that would see this conflict
+# are not added in the future, add the `time` feature in dev dependencies. This is a "regression test" of sorts, in
+# that it will enable the `time` feature in tests/examples, simulating the behavior of a consumer of `pgmq` that has
+# both the `time` and `chrono` features enabled. If a query that would see the conflict is added, `pgmq` will fail to
+# compile when running tests/examples.
 sqlx = { version = "0.8.1", features = ["time"] }

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -29,3 +29,7 @@ env_logger = "0.10.0"
 rand = "0.8.5"
 regex = "1.5.4"
 lazy_static = "1.4.0"
+# Enable the `time` feature in dev dependencies to ensure we are able to support consumers who have
+# the feature enabled, either directly or via a transitive dependency. See the following issue for
+# more details: https://github.com/launchbadge/sqlx/issues/3412
+sqlx = { version = "0.8.1", features = ["time"] }

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."


### PR DESCRIPTION
Problem
-------
If a consumer has both the `time` and `chrono` features of `sqlx` enabled, `sqlx` will default to using `OffsetDateTime` (from [`time`](https://docs.rs/time)) for timestamp fields instead of `DateTime<Utc>` (from [`chrono`](https://docs.rs/chrono)). It's easy to accidentally encounter this situation, either by directly enabling `time`, e.g., if the consumer prefers `time` over `chrono`, or if the `time` feature is enabled by a transitive dependency. When this situation occurs, the `pg_ext::PGMQueueMeta` struct can not be built from the sqlx query because an `OffsetDateTime` was returned instead of a `DateTime<Utc>`, causing a compile error.

Solution
--------
`sqlx` provides a way to override the type of an output column: https://docs.rs/sqlx/latest/sqlx/macro.query.html#force-a-differentcustom-type. This PR updates the failing queries in the `pg_ext` to use this approach. Unfortunately, I think this requires using the more verbose approach of naming each column to be returned instead of using `*`.

Testing
-------
- I ran `cargo test` locally and all the tests passed
- I ran the examples and they appeared to run successfully
- I enabled the `time` feature of `sqlx` in the `dev-dependencies` to ensure this case of enabling `chrono` and `time` is supported, which can be confirmed by compiling examples/tests.

Other
-----
I also updated the sqlx query caches by running `cargo sqlx prepare` locally. I noticed there was an unused column called `headers` in some of the queries that used a `*` selector. I can add the column back, but it didn't appear to be used, so I left it out.