### PR TITLE
add prisma-pgmq to community

### DIFF
--- a/pgmq-extension/README.md
+++ b/pgmq-extension/README.md
@@ -76,6 +76,7 @@ Community
 - [.NET](https://github.com/brianpursley/Npgmq)
 - [Python (with SQLAlchemy)](https://github.com/jason810496/pgmq-sqlalchemy)
 - [REST-API (Bun + Elysia)](https://github.com/eichenroth/pgmq-rest)
+- [TypeScript (NodeJs + Prisma)](https://github.com/dvlkv/prisma-pgmq) 
 
 ## SQL Examples
 


### PR DESCRIPTION
I created a library for Prisma: [prisma-pgmq](https://github.com/dvlkv/prisma-pgmq) 

At first I tried to create an extension, but noticed that the extensions ignore [transactions](https://www.prisma.io/docs/orm/prisma-client/client-extensions/shared-extensions#call-a-client-level-method-from-your-packaged-extension).

So, this library just implements all pgmq API as a utility functions, using @prisma/client as peerDependency