### PR TITLE
patch extension config dump

### DIFF
--- a/pgmq-extension/pgmq.control
+++ b/pgmq-extension/pgmq.control
@@ -1,5 +1,5 @@
 comment = 'A lightweight message queue. Like AWS SQS and RSMQ but on Postgres.'
-default_version = '1.6.0'
+default_version = '1.6.1'
 module_pathname = '$libdir/pgmq'
 schema = 'pgmq'
 relocatable = false

--- a/pgmq-extension/sql/pgmq--1.6.0--1.6.1.sql
+++ b/pgmq-extension/sql/pgmq--1.6.0--1.6.1.sql
@@ -1,0 +1,9 @@
+-- Allow pgmq.meta to be dumped by `pg_dump` when pgmq is installed as an extension
+DO
+$$
+BEGIN
+    IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
+        PERFORM pg_catalog.pg_extension_config_dump('pgmq.meta', '');
+    END IF;
+END
+$$;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -21,12 +21,12 @@ CREATE TABLE IF NOT EXISTS pgmq.meta (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL
 );
 
--- Allow pgma.meta to be dumped by `pg_dump` when pgmq is installed as an extension
+-- Allow pgmq.meta to be dumped by `pg_dump` when pgmq is installed as an extension
 DO
 $$
 BEGIN
-    IF (SELECT NOT EXISTS( SELECT 1 FROM pg_extension WHERE extname = 'pgmq')) THEN
-      SELECT pg_catalog.pg_extension_config_dump('pgmq.meta', '');
+    IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
+        PERFORM pg_catalog.pg_extension_config_dump('pgmq.meta', '');
     END IF;
 END
 $$;


### PR DESCRIPTION
1.  fixes the condition on when to execute `pg_extension_config_dump`
2. `PERFORM` is more semantically correct use for `pg_extension_config_dump`

The condition was patched in the migration in https://github.com/pgmq/pgmq/pull/416 but should have also been updated in the main sql file.