### PR TITLE
Add new queue notification feature

### DIFF
--- a/pgmq-extension/pgmq.control
+++ b/pgmq-extension/pgmq.control
@@ -1,5 +1,5 @@
 comment = 'A lightweight message queue. Like AWS SQS and RSMQ but on Postgres.'
-default_version = '1.6.1'
+default_version = '1.7.0'
 module_pathname = '$libdir/pgmq'
 schema = 'pgmq'
 relocatable = false

--- a/pgmq-extension/sql/pgmq--1.6.1--1.7.0.sql
+++ b/pgmq-extension/sql/pgmq--1.6.1--1.7.0.sql
@@ -11,6 +11,7 @@ RETURNS void AS $$
 DECLARE
   qtable TEXT := pgmq.format_table_name(queue_name, 'q');
 BEGIN
+  PERFORM pgmq.disable_notify_insert(queue_name);
   EXECUTE FORMAT(
     $QUERY$
     CREATE CONSTRAINT TRIGGER trigger_notify_queue_insert_listeners
@@ -30,7 +31,7 @@ DECLARE
 BEGIN
   EXECUTE FORMAT(
     $QUERY$
-    DROP TRIGGER trigger_notify_queue_insert_listeners ON pgmq.%I;
+    DROP TRIGGER IF EXISTS trigger_notify_queue_insert_listeners ON pgmq.%I;
     $QUERY$,
     qtable
   );

--- a/pgmq-extension/sql/pgmq--1.6.1--1.7.0.sql
+++ b/pgmq-extension/sql/pgmq--1.6.1--1.7.0.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION pgmq.notify_queue_listeners()
+RETURNS TRIGGER AS $$
+BEGIN
+  PERFORM PG_NOTIFY('pgmq.' || TG_TABLE_NAME || '.' || TG_OP, NULL);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pgmq.enable_notify_insert(queue_name TEXT)
+RETURNS void AS $$
+DECLARE
+  qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+  EXECUTE FORMAT(
+    $QUERY$
+    CREATE CONSTRAINT TRIGGER trigger_notify_queue_insert_listeners
+    AFTER INSERT ON pgmq.%I
+    DEFERRABLE FOR EACH ROW
+    EXECUTE PROCEDURE pgmq.notify_queue_listeners()
+    $QUERY$,
+    qtable
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pgmq.disable_notify_insert(queue_name TEXT)
+RETURNS void AS $$
+DECLARE
+  qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+  EXECUTE FORMAT(
+    $QUERY$
+    DROP TRIGGER trigger_notify_queue_insert_listeners ON pgmq.%I;
+    $QUERY$,
+    qtable
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -1134,29 +1134,29 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pgmq.enable_notifications(queue_name TEXT)
+CREATE OR REPLACE FUNCTION pgmq.enable_notify_insert(queue_name TEXT)
 RETURNS void AS $$
 BEGIN
   EXECUTE FORMAT(
     $QUERY$
-    CREATE CONSTRAINT TRIGGER trigger_notify_queue_listeners
-    AFTER INSERT OR UPDATE OR DELETE ON pgmq.%I
+    CREATE CONSTRAINT TRIGGER trigger_notify_queue_insert_listeners
+    AFTER INSERT ON pgmq.%I
     DEFERRABLE FOR EACH ROW
     EXECUTE PROCEDURE pgmq.notify_queue_listeners()
     $QUERY$,
-    'q_' || queue_name
+    ('q_' || queue_name)::regclass
   );
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pgmq.disable_notifications(queue_name TEXT)
+CREATE OR REPLACE FUNCTION pgmq.disable_notify_insert(queue_name TEXT)
 RETURNS void AS $$
 BEGIN
   EXECUTE FORMAT(
     $QUERY$
-    DROP TRIGGER trigger_notify_queue_listeners ON pgmq.%I;
+    DROP TRIGGER trigger_notify_queue_insert_listeners ON pgmq.%I;
     $QUERY$,
-    'q_' || queue_name
+    ('q_' || queue_name)::regclass
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -1129,7 +1129,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION pgmq.notify_queue_listeners()
 RETURNS TRIGGER AS $$
 BEGIN
-  PERFORM pg_notify(TG_TABLE_NAME, TG_OP);
+  PERFORM PG_NOTIFY('pgmq.' || TG_TABLE_NAME || '.' || TG_OP, NULL);
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -1140,11 +1140,11 @@ BEGIN
   EXECUTE FORMAT(
     $QUERY$
     CREATE CONSTRAINT TRIGGER trigger_notify_queue_insert_listeners
-    AFTER INSERT ON pgmq.%I
+    AFTER INSERT ON %I
     DEFERRABLE FOR EACH ROW
     EXECUTE PROCEDURE pgmq.notify_queue_listeners()
     $QUERY$,
-    ('q_' || queue_name)::regclass
+    ('pgmq.q_' || queue_name)::regclass
   );
 END;
 $$ LANGUAGE plpgsql;
@@ -1154,9 +1154,9 @@ RETURNS void AS $$
 BEGIN
   EXECUTE FORMAT(
     $QUERY$
-    DROP TRIGGER trigger_notify_queue_insert_listeners ON pgmq.%I;
+    DROP TRIGGER trigger_notify_queue_insert_listeners ON %I;
     $QUERY$,
-    ('q_' || queue_name)::regclass
+    ('pgmq.q_' || queue_name)::regclass
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -1139,6 +1139,7 @@ RETURNS void AS $$
 DECLARE
   qtable TEXT := pgmq.format_table_name(queue_name, 'q');
 BEGIN
+  PERFORM pgmq.disable_notify_insert(queue_name);
   EXECUTE FORMAT(
     $QUERY$
     CREATE CONSTRAINT TRIGGER trigger_notify_queue_insert_listeners
@@ -1158,7 +1159,7 @@ DECLARE
 BEGIN
   EXECUTE FORMAT(
     $QUERY$
-    DROP TRIGGER trigger_notify_queue_insert_listeners ON pgmq.%I;
+    DROP TRIGGER IF EXISTS trigger_notify_queue_insert_listeners ON pgmq.%I;
     $QUERY$,
     qtable
   );

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -1125,3 +1125,39 @@ BEGIN
   );
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pgmq.notify_queue_listeners()
+RETURNS TRIGGER AS $$
+BEGIN
+  PERFORM pg_notify(TG_TABLE_NAME, TG_OP);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pgmq.enable_notifications(queue_name TEXT)
+RETURNS void AS $$
+BEGIN
+  EXECUTE FORMAT(
+    $QUERY$
+    CREATE CONSTRAINT TRIGGER trigger_notify_queue_listeners
+    AFTER INSERT OR UPDATE OR DELETE ON pgmq.%I
+    DEFERRABLE FOR EACH ROW
+    EXECUTE PROCEDURE pgmq.notify_queue_listeners()
+    $QUERY$,
+    'q_' || queue_name
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pgmq.disable_notifications(queue_name TEXT)
+RETURNS void AS $$
+BEGIN
+  EXECUTE FORMAT(
+    $QUERY$
+    DROP TRIGGER trigger_notify_queue_listeners ON pgmq.%I;
+    $QUERY$,
+    'q_' || queue_name
+  );
+END;
+$$ LANGUAGE plpgsql;
+

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -1136,27 +1136,31 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION pgmq.enable_notify_insert(queue_name TEXT)
 RETURNS void AS $$
+DECLARE
+  qtable TEXT := pgmq.format_table_name(queue_name, 'q');
 BEGIN
   EXECUTE FORMAT(
     $QUERY$
     CREATE CONSTRAINT TRIGGER trigger_notify_queue_insert_listeners
-    AFTER INSERT ON %I
+    AFTER INSERT ON pgmq.%I
     DEFERRABLE FOR EACH ROW
     EXECUTE PROCEDURE pgmq.notify_queue_listeners()
     $QUERY$,
-    ('pgmq.q_' || queue_name)::regclass
+    qtable
   );
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION pgmq.disable_notify_insert(queue_name TEXT)
 RETURNS void AS $$
+DECLARE
+  qtable TEXT := pgmq.format_table_name(queue_name, 'q');
 BEGIN
   EXECUTE FORMAT(
     $QUERY$
-    DROP TRIGGER trigger_notify_queue_insert_listeners ON %I;
+    DROP TRIGGER trigger_notify_queue_insert_listeners ON pgmq.%I;
     $QUERY$,
-    ('pgmq.q_' || queue_name)::regclass
+    qtable
   );
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Add new queue notification feature that notifies listeners about inserts, updates and deletions of messages. This is opt-in and can be enabled/disabled on a per-queue basis. This feature requires client support as LISTEN/NOTIFY alone do not help much. This is a starting point to allow real-time updates additionally to polling.