### PR TITLE
feat: Add "read grouped" methods to `Queue` and impl for all sql drivers

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -778,9 +778,8 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
-
-        Self::read_batch_common(query, queue_name, vt, qty, executor).await
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::read_grouped(executor, queue_name, vt.into(), qty).await
     }
 
     pub async fn read_grouped<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
@@ -863,9 +862,8 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_head(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
-
-        Self::read_batch_common(query, queue_name, vt, qty, executor).await
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::read_grouped_head(executor, queue_name, vt.into(), qty).await
     }
 
     pub async fn read_grouped_head<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
@@ -890,9 +888,8 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_rr(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
-
-        Self::read_batch_common(query, queue_name, vt, qty, executor).await
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::read_grouped_rr(executor, queue_name, vt.into(), qty).await
     }
 
     pub async fn read_grouped_rr<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -41,7 +41,7 @@ macro_rules! diesel_functions {
             queue_name: crate::types::QueueName<'_>,
             message: serde_json::Value,
             headers: serde_json::Value,
-            delay: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset,
+            delay: crate::types::VisibilityTimeoutOffset,
         ) -> Result<i64, crate::PgmqError>
         where
             C: $executor_trait,
@@ -58,7 +58,7 @@ macro_rules! diesel_functions {
             queue_name: crate::types::QueueName<'_>,
             messages: Vec<serde_json::Value>,
             headers: Option<Vec<serde_json::Value>>,
-            delay: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset,
+            delay: crate::types::VisibilityTimeoutOffset,
         ) -> Result<Vec<i64>, crate::PgmqError>
         where
             C: $executor_trait,
@@ -73,7 +73,7 @@ macro_rules! diesel_functions {
         async fn read<C, T, H>(
             executor: &mut C,
             queue_name: crate::types::QueueName<'_>,
-            visibility_timeout: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
             quantity: i32,
         ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
         where
@@ -136,7 +136,7 @@ macro_rules! diesel_functions {
             executor: &mut C,
             queue_name: crate::types::QueueName<'_>,
             msg_ids: &'_ [i64],
-            visibility_timeout: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
         ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
         where
             C: $executor_trait,
@@ -171,6 +171,69 @@ macro_rules! diesel_functions {
                 crate::queue::diesel::query::create_fifo_indexes_all_query().execute(executor);
             $transform_result!(result)?;
             Ok(())
+        }
+
+        async fn read_grouped<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages = crate::queue::diesel::query::read_grouped_query(
+                queue_name,
+                visibility_timeout,
+                quantity,
+            )
+            .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
+        }
+
+        async fn read_grouped_head<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages = crate::queue::diesel::query::read_grouped_head_query(
+                queue_name,
+                visibility_timeout,
+                quantity,
+            )
+            .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
+        }
+
+        async fn read_grouped_rr<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages = crate::queue::diesel::query::read_grouped_rr_query(
+                queue_name,
+                visibility_timeout,
+                quantity,
+            )
+            .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
         }
     };
 }

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,7 +1,8 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
 use crate::queue::diesel::sql::{
     pgmq_archive, pgmq_create, pgmq_create_fifo_index, pgmq_create_fifo_indexes_all, pgmq_delete,
-    pgmq_pop, pgmq_read, pgmq_send, pgmq_send_batch, pgmq_set_vt,
+    pgmq_pop, pgmq_read, pgmq_read_grouped, pgmq_read_grouped_head, pgmq_read_grouped_rr,
+    pgmq_send, pgmq_send_batch, pgmq_set_vt,
 };
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
@@ -85,4 +86,45 @@ pub fn create_fifo_index_query(queue_name: QueueName<'_>) -> _ {
 #[diesel::dsl::auto_type(no_type_alias)]
 pub fn create_fifo_indexes_all_query() -> _ {
     select(pgmq_create_fifo_indexes_all())
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn read_grouped_query(
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    select(pgmq_read_grouped(queue_name, visibility_timeout, quantity))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn read_grouped_head_query(
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    select(pgmq_read_grouped_head(
+        queue_name,
+        visibility_timeout,
+        quantity,
+    ))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn read_grouped_rr_query(
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    select(pgmq_read_grouped_rr(
+        queue_name,
+        visibility_timeout,
+        quantity,
+    ))
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -95,4 +95,13 @@ extern "SQL" {
 
     #[sql_name = "pgmq.create_fifo_indexes_all"]
     fn pgmq_create_fifo_indexes_all();
+
+    #[sql_name = "pgmq.read_grouped"]
+    fn pgmq_read_grouped(queue_name: Text, vt: Integer, qty: Integer) -> PgMessage;
+
+    #[sql_name = "pgmq.read_grouped_head"]
+    fn pgmq_read_grouped_head(queue_name: Text, vt: Integer, qty: Integer) -> PgMessage;
+
+    #[sql_name = "pgmq.read_grouped_rr"]
+    fn pgmq_read_grouped_rr(queue_name: Text, vt: Integer, qty: Integer) -> PgMessage;
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -243,6 +243,84 @@ macro_rules! impl_queue {
             async fn create_fifo_indexes_all(self) -> Result<(), crate::PgmqError> {
                 create_fifo_indexes_all($transform_self!(self)).await
             }
+
+            async fn read_grouped<'q, T, H, Q, QE, VT>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                read_grouped(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                )
+                .await
+            }
+
+            async fn read_grouped_head<'q, T, H, Q, QE, VT>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                read_grouped_head(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                )
+                .await
+            }
+
+            async fn read_grouped_rr<'q, T, H, Q, QE, VT>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                read_grouped_rr(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                )
+                .await
+            }
         }
     };
 }

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -356,4 +356,149 @@ pub trait Queue: crate::private::Sealed {
     /// # }
     /// ```
     async fn create_fifo_indexes_all(self) -> Result<(), PgmqError>;
+
+    /// Reads messages with AWS SQS FIFO-style batch retrieval behavior. Returns at most `quantity`
+    /// messages from the same FIFO group from the queue with the provided `queue_name`. If no
+    /// messages are available, an empty [`Vec`] will be returned.
+    ///
+    /// Invokes the `pgmq.read_grouped` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read_grouped("my_queue", 10, 1).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`)
+    /// let msgs: Vec<Message<MyMessage>> = queue.read_grouped("my_queue", Duration::from_secs(10), 2).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn read_grouped<'q, T, H, Q, QE, VT>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>,
+        VT: Send + Into<VisibilityTimeoutOffset>;
+
+    /// Read the head of at most `quantity` FIFO groups from the queue with the provided
+    /// `queue_name`. This supports horizontal scaling by processing groups in parallel while
+    /// ensuring message ordering is preserved per group. If no messages are available, an
+    /// empty [`Vec`] will be returned.
+    ///
+    /// Invokes the `pgmq.read_grouped_head` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read_grouped_head("my_queue", 10, 1).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`)
+    /// let msgs: Vec<Message<MyMessage>> = queue.read_grouped_head("my_queue", Duration::from_secs(10), 2).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn read_grouped_head<'q, T, H, Q, QE, VT>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>,
+        VT: Send + Into<VisibilityTimeoutOffset>;
+
+    /// Read at most `quantity` messages from the queue with the provided `queue_name`. Preserves
+    /// FIFO order within groups and interleaves across groups (layered round-robin). If no
+    /// messages are available, an empty [`Vec`] will be returned.
+    ///
+    /// Invokes the `pgmq.read_grouped_rr` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read_grouped_rr("my_queue", 10, 1).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`)
+    /// let msgs: Vec<Message<MyMessage>> = queue.read_grouped_rr("my_queue", Duration::from_secs(10), 2).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn read_grouped_rr<'q, T, H, Q, QE, VT>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>,
+        VT: Send + Into<VisibilityTimeoutOffset>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -119,16 +119,14 @@ macro_rules! rust_postgres_functions {
             T: for<'de> serde::Deserialize<'de>,
             H: for<'de> serde::Deserialize<'de>,
         {
-            let params: [crate::queue::rust_postgres::SqlParam; _] = [
-                (&*queue_name, postgres_types::Type::TEXT),
-                (&*visibility_timeout, postgres_types::Type::INT4),
-                (&quantity, postgres_types::Type::INT4),
-            ];
-            let rows = executor.query_typed(crate::queue::sql::READ, &params);
-            let rows = $transform_result!(rows)?;
-            rows.into_iter()
-                .map(|row| crate::Message::<T, H>::try_from(row))
-                .collect::<Result<Vec<crate::Message<T, H>>, crate::PgmqError>>()
+            read_common(
+                executor,
+                crate::queue::sql::READ,
+                queue_name,
+                visibility_timeout,
+                quantity,
+            )
+            .await
         }
 
         async fn pop<C, T, H>(
@@ -238,6 +236,93 @@ macro_rules! rust_postgres_functions {
             let result = executor.execute_typed(crate::queue::sql::CREATE_FIFO_INDEXES_ALL, &[]);
             $transform_result!(result)?;
             Ok(())
+        }
+
+        async fn read_grouped<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            read_common(
+                executor,
+                crate::queue::sql::READ_GROUPED,
+                queue_name,
+                visibility_timeout,
+                quantity,
+            )
+            .await
+        }
+
+        async fn read_grouped_head<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            read_common(
+                executor,
+                crate::queue::sql::READ_GROUPED_HEAD,
+                queue_name,
+                visibility_timeout,
+                quantity,
+            )
+            .await
+        }
+
+        async fn read_grouped_rr<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            read_common(
+                executor,
+                crate::queue::sql::READ_GROUPED_RR,
+                queue_name,
+                visibility_timeout,
+                quantity,
+            )
+            .await
+        }
+
+        async fn read_common<C, T, H>(
+            executor: $ref_type!(C),
+            query: &'static str,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&*queue_name, postgres_types::Type::TEXT),
+                (&*visibility_timeout, postgres_types::Type::INT4),
+                (&quantity, postgres_types::Type::INT4),
+            ];
+            let rows = executor.query_typed(query, &params);
+            let rows = $transform_result!(rows)?;
+            rows.into_iter()
+                .map(|row| crate::Message::<T, H>::try_from(row))
+                .collect::<Result<Vec<crate::Message<T, H>>, crate::PgmqError>>()
         }
     };
 }

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -32,3 +32,12 @@ pub const CREATE_FIFO_INDEX: &str = "SELECT pgmq.create_fifo_index(queue_name=>$
 
 // language=PostgreSQL
 pub const CREATE_FIFO_INDEXES_ALL: &str = "SELECT pgmq.create_fifo_indexes_all()";
+
+// language=PostgreSQL
+pub const READ_GROUPED: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers FROM pgmq.read_grouped(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)";
+
+// language=PostgreSQL
+pub const READ_GROUPED_HEAD: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers FROM pgmq.read_grouped_head(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)";
+
+// language=PostgreSQL
+pub const READ_GROUPED_RR: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers FROM pgmq.read_grouped_rr(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,7 +1,7 @@
 use crate::queue::macros::{identity_macro, impl_queue};
 use crate::queue::sql::{
-    ARCHIVE, CREATE, CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, DELETE, POP, READ, SEND,
-    SEND_BATCH, SET_VT,
+    ARCHIVE, CREATE, CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, DELETE, POP, READ, READ_GROUPED,
+    READ_GROUPED_HEAD, READ_GROUPED_RR, SEND, SEND_BATCH, SET_VT,
 };
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::{Message, PgmqError};
@@ -88,15 +88,7 @@ where
     T: for<'de> serde::Deserialize<'de>,
     H: for<'de> serde::Deserialize<'de>,
 {
-    let query = sqlx::query(READ);
-    let rows = query
-        .bind(*queue_name)
-        .bind(visibility_timeout)
-        .bind(quantity)
-        .fetch_all(executor)
-        .await?;
-
-    handle_read_batch_result(rows)
+    read_common(executor, READ, queue_name, visibility_timeout, quantity).await
 }
 
 pub(crate) async fn pop<'c, C, T, H>(
@@ -196,4 +188,90 @@ where
         .await?;
 
     Ok(())
+}
+
+pub(crate) async fn read_grouped<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    read_common(
+        executor,
+        READ_GROUPED,
+        queue_name,
+        visibility_timeout,
+        quantity,
+    )
+    .await
+}
+
+pub(crate) async fn read_grouped_head<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    read_common(
+        executor,
+        READ_GROUPED_HEAD,
+        queue_name,
+        visibility_timeout,
+        quantity,
+    )
+    .await
+}
+
+pub(crate) async fn read_grouped_rr<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    read_common(
+        executor,
+        READ_GROUPED_RR,
+        queue_name,
+        visibility_timeout,
+        quantity,
+    )
+    .await
+}
+
+async fn read_common<'c, C, T, H>(
+    executor: C,
+    query: &'static str,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    let query = sqlx::query(query);
+    let rows = query
+        .bind(*queue_name)
+        .bind(visibility_timeout)
+        .bind(quantity)
+        .fetch_all(executor)
+        .await?;
+
+    handle_read_batch_result(rows)
 }

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -545,3 +545,266 @@ async fn create_fifo_indexes_all(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
     queue.create_fifo_indexes_all().await.unwrap();
 }
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message>, _> = queue.read_grouped("invalid-queue-name", 10, 1).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_default_group(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let msg1 = TestMessage::new();
+    let id1 = queue.send(QUEUE, &msg1, EMPTY_HEADERS, 0).await.unwrap();
+    let msg2 = TestMessage::new();
+    let _ = queue.send(QUEUE, &msg2, EMPTY_HEADERS, 0).await.unwrap();
+
+    {
+        let read_msg1: Option<Message<TestMessage>> = queue
+            .read_grouped(QUEUE, 100, 1)
+            .await
+            .unwrap()
+            .into_iter()
+            .next();
+        let read_msg2: Option<Message<TestMessage>> = queue
+            .read_grouped(QUEUE, 100, 1)
+            .await
+            .unwrap()
+            .into_iter()
+            .next();
+        assert!(read_msg1.is_some());
+        assert!(read_msg2.is_none(), "The second message should not become available until the first message has been processed");
+    }
+
+    {
+        queue.archive(QUEUE, &[id1]).await.unwrap();
+        let read_msg2: Option<Message<TestMessage>> = queue
+            .read_grouped(QUEUE, 100, 1)
+            .await
+            .unwrap()
+            .into_iter()
+            .next();
+        assert!(read_msg2.is_some());
+    }
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_default_group_many(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let msg1 = TestMessage::new();
+    queue.send(QUEUE, &msg1, EMPTY_HEADERS, 0).await.unwrap();
+    let msg2 = TestMessage::new();
+    queue.send(QUEUE, &msg2, EMPTY_HEADERS, 0).await.unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> = queue.read_grouped(QUEUE, 100, 2).await.unwrap();
+    assert_eq!(2, read_msgs.len());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_custom_group(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let msg1 = TestMessage {
+        a: "a".to_string(),
+        b: 1,
+    };
+    let headers1 = json!({
+        "x-pgmq-group": msg1.b
+    });
+    let msg2 = TestMessage {
+        a: "b".to_string(),
+        b: 2,
+    };
+    let headers2 = json!({
+        "x-pgmq-group": msg2.b
+    });
+    queue
+        .send_batch(QUEUE, &[msg1, msg2], Some(&[headers1, headers2]), 0)
+        .await
+        .unwrap();
+
+    let read_msg1: Option<Message<TestMessage>> = queue
+        .read_grouped(QUEUE, 100, 1)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    let read_msg2: Option<Message<TestMessage>> = queue
+        .read_grouped(QUEUE, 100, 1)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    assert!(read_msg1.is_some());
+    assert!(read_msg2.is_some());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_head_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message>, _> =
+        queue.read_grouped_head("invalid-queue-name", 10, 1).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_head_diff_groups(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let msg1 = TestMessage {
+        a: "a".to_string(),
+        b: 1,
+    };
+    let headers1 = json!({
+        "x-pgmq-group": msg1.b
+    });
+    let msg2 = TestMessage {
+        a: "b".to_string(),
+        b: 1,
+    };
+    let headers2 = json!({
+        "x-pgmq-group": msg2.b
+    });
+    let msg3 = TestMessage {
+        a: "c".to_string(),
+        b: 2,
+    };
+    let headers3 = json!({
+        "x-pgmq-group": msg3.b
+    });
+    let msg4 = TestMessage {
+        a: "d".to_string(),
+        b: 2,
+    };
+    let headers4 = json!({
+        "x-pgmq-group": msg4.b
+    });
+    queue
+        .send_batch(
+            QUEUE,
+            &[msg1, msg2, msg3, msg4],
+            Some(&[headers1, headers2, headers3, headers4]),
+            0,
+        )
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> =
+        queue.read_grouped_head(QUEUE, 100, 2).await.unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.b,
+        read_msgs.get(1).unwrap().message.b
+    );
+
+    let read_msgs2: Vec<Message<TestMessage>> =
+        queue.read_grouped_head(QUEUE, 100, 2).await.unwrap();
+    assert!(read_msgs2.is_empty(), "The second message in each group should not become available until the first message has been processed");
+
+    queue
+        .archive(
+            QUEUE,
+            &read_msgs.iter().map(|msg| msg.msg_id).collect::<Vec<_>>(),
+        )
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> =
+        queue.read_grouped_head(QUEUE, 100, 2).await.unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.b,
+        read_msgs.get(1).unwrap().message.b
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_rr_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message>, _> = queue.read_grouped_rr("invalid-queue-name", 10, 1).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_rr_diff_groups(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let msg1 = TestMessage {
+        a: "a".to_string(),
+        b: 1,
+    };
+    let headers1 = json!({
+        "x-pgmq-group": msg1.b
+    });
+    let msg2 = TestMessage {
+        a: "b".to_string(),
+        b: 1,
+    };
+    let headers2 = json!({
+        "x-pgmq-group": msg2.b
+    });
+    let msg3 = TestMessage {
+        a: "c".to_string(),
+        b: 2,
+    };
+    let headers3 = json!({
+        "x-pgmq-group": msg3.b
+    });
+    let msg4 = TestMessage {
+        a: "d".to_string(),
+        b: 2,
+    };
+    let headers4 = json!({
+        "x-pgmq-group": msg4.b
+    });
+    queue
+        .send_batch(
+            QUEUE,
+            &[msg1, msg2, msg3, msg4],
+            Some(&[headers1, headers2, headers3, headers4]),
+            0,
+        )
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> = queue.read_grouped_rr(QUEUE, 100, 2).await.unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.b,
+        read_msgs.get(1).unwrap().message.b
+    );
+
+    let read_msgs2: Vec<Message<TestMessage>> = queue.read_grouped_rr(QUEUE, 100, 2).await.unwrap();
+    assert!(read_msgs2.is_empty(), "The second message in each group should not become available until the first message has been processed");
+
+    queue
+        .archive(
+            QUEUE,
+            &read_msgs.iter().map(|msg| msg.msg_id).collect::<Vec<_>>(),
+        )
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> = queue.read_grouped_rr(QUEUE, 100, 2).await.unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.b,
+        read_msgs.get(1).unwrap().message.b
+    );
+}


### PR DESCRIPTION
This PR adds `read_grouped`, `read_grouped_head`, and `read_grouped_rr` methods to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres). This PR also updates `PGMQueueExt#read_grouped*` to use the sqlx implementation of `Queue`.

The new tests in `tests/queue.rs` were copied from the existing tests in `pg_ext_integration_test.rs` and translated to use the `Queue` trait methods.

Relates to https://github.com/pgmq/pgmq/issues/425