### PR TITLE
feat: Add topic-based routing methods and impl for all sql drivers

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1149,14 +1149,8 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_queue_name(queue_name)?;
-        sqlx::query("SELECT pgmq.bind_topic(pattern=>$1::text, queue_name=>$2::text)")
-            .bind(pattern)
-            .bind(queue_name)
-            .execute(executor)
-            .await?;
-
-        Ok(())
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::bind_topic(executor, pattern, queue_name).await
     }
 
     pub async fn bind_topic(&self, pattern: &str, queue_name: &str) -> Result<(), PgmqError> {
@@ -1170,14 +1164,8 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_queue_name(queue_name)?;
-        sqlx::query("SELECT pgmq.unbind_topic(pattern=>$1::text, queue_name=>$2::text)")
-            .bind(pattern)
-            .bind(queue_name)
-            .execute(executor)
-            .await?;
-
-        Ok(())
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::unbind_topic(executor, pattern, queue_name).await
     }
 
     pub async fn unbind_topic(&self, pattern: &str, queue_name: &str) -> Result<(), PgmqError> {
@@ -1190,18 +1178,8 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<Vec<ListTopicBindingsRow>, PgmqError> {
-        let rows = sqlx::query(
-            "SELECT pattern, queue_name, bound_at, compiled_regex from pgmq.list_topic_bindings(queue_name=>$1::text);",
-        )
-            .bind(queue_name)
-            .fetch_all(executor)
-            .await?;
-
-        let rows = rows
-            .into_iter()
-            .map(|row| ListTopicBindingsRow::from_row(&row))
-            .collect::<Result<Vec<ListTopicBindingsRow>, _>>()?;
-        Ok(rows)
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::list_topic_bindings(executor, queue_name).await
     }
 
     pub async fn list_topic_bindings(
@@ -1219,17 +1197,7 @@ impl PGMQueueExt {
         &self,
         executor: E,
     ) -> Result<Vec<ListTopicBindingsRow>, PgmqError> {
-        let rows = sqlx::query(
-            "SELECT pattern, queue_name, bound_at, compiled_regex from pgmq.list_topic_bindings();",
-        )
-        .fetch_all(executor)
-        .await?;
-
-        let rows = rows
-            .into_iter()
-            .map(|row| ListTopicBindingsRow::from_row(&row))
-            .collect::<Result<Vec<ListTopicBindingsRow>, _>>()?;
-        Ok(rows)
+        crate::queue::sqlx::list_topic_bindings_all(executor).await
     }
 
     pub async fn list_topic_bindings_all(&self) -> Result<Vec<ListTopicBindingsRow>, PgmqError> {
@@ -1256,15 +1224,7 @@ impl PGMQueueExt {
         let delay: VisibilityTimeoutOffset = delay.into();
         let message = serde_json::to_value(message)?;
         let headers = serde_json::to_value(headers)?;
-        let matched_queue_count = sqlx::query_scalar("SELECT * from pgmq.send_topic(routing_key=>$1::text, msg=>$2::jsonb, headers=>$3::jsonb, delay=>$4::int)")
-            .bind(routing_key)
-            .bind(message)
-            .bind(headers)
-            .bind(delay)
-            .fetch_one(executor)
-            .await?;
-
-        Ok(matched_queue_count)
+        crate::queue::sqlx::send_topic(executor, routing_key, message, headers, delay).await
     }
 
     pub async fn send_topic<T: Serialize, H: Serialize>(
@@ -1296,21 +1256,7 @@ impl PGMQueueExt {
         let delay: VisibilityTimeoutOffset = delay.into();
         let messages = serialize_list(messages)?;
         let headers = serialize_optional_list(headers)?;
-        let sent = sqlx::query(
-            "SELECT queue_name, msg_id from pgmq.send_batch_topic(routing_key=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer);",
-        )
-            .bind(routing_key)
-            .bind(messages)
-            .bind(headers)
-            .bind(delay)
-            .fetch_all(executor)
-            .await?;
-
-        let sent = sent
-            .into_iter()
-            .map(|row| SendBatchTopicRow::from_row(&row))
-            .collect::<Result<Vec<SendBatchTopicRow>, _>>()?;
-        Ok(sent)
+        crate::queue::sqlx::send_batch_topic(executor, routing_key, messages, headers, delay).await
     }
 
     pub async fn send_batch_topic<T: Serialize, H: Serialize>(

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -235,6 +235,97 @@ macro_rules! diesel_functions {
             let messages = $transform_result!(messages)?;
             Ok(messages)
         }
+
+        async fn bind_topic<C>(
+            executor: &mut C,
+            pattern: &str,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result = crate::queue::diesel::query::bind_topic_query(pattern, queue_name)
+                .execute(executor);
+            $transform_result!(result)?;
+            Ok(())
+        }
+
+        async fn unbind_topic<C>(
+            executor: &mut C,
+            pattern: &str,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result = crate::queue::diesel::query::unbind_topic_query(pattern, queue_name)
+                .execute(executor);
+            $transform_result!(result)?;
+            Ok(())
+        }
+
+        async fn list_topic_bindings<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<Vec<crate::types::ListTopicBindingsRow>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let rows = crate::queue::diesel::query::list_topic_bindings_query(queue_name)
+                .get_results(executor);
+            let rows = $transform_result!(rows)?;
+            Ok(rows)
+        }
+
+        async fn list_topic_bindings_all<C>(
+            executor: &mut C,
+        ) -> Result<Vec<crate::types::ListTopicBindingsRow>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let rows =
+                crate::queue::diesel::query::list_topic_bindings_all_query().get_results(executor);
+            let rows = $transform_result!(rows)?;
+            Ok(rows)
+        }
+
+        async fn send_topic<C>(
+            executor: &mut C,
+            routing_key: &str,
+            message: serde_json::Value,
+            headers: serde_json::Value,
+            delay: crate::types::VisibilityTimeoutOffset,
+        ) -> Result<i32, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let matched_queue_count =
+                crate::queue::diesel::query::send_topic_query(routing_key, message, headers, delay)
+                    .get_result(executor);
+            let matched_queue_count = $transform_result!(matched_queue_count)?;
+            Ok(matched_queue_count)
+        }
+
+        async fn send_batch_topic<C>(
+            executor: &mut C,
+            routing_key: &str,
+            messages: Vec<serde_json::Value>,
+            headers: Option<Vec<serde_json::Value>>,
+            delay: crate::types::VisibilityTimeoutOffset,
+        ) -> Result<Vec<crate::types::SendBatchTopicRow>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let rows = crate::queue::diesel::query::send_batch_topic_query(
+                routing_key,
+                messages,
+                headers,
+                delay,
+            )
+            .get_results(executor);
+            let rows = $transform_result!(rows)?;
+            Ok(rows)
+        }
     };
 }
 pub(crate) use diesel_functions;

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,8 +1,10 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
 use crate::queue::diesel::sql::{
-    pgmq_archive, pgmq_create, pgmq_create_fifo_index, pgmq_create_fifo_indexes_all, pgmq_delete,
-    pgmq_pop, pgmq_read, pgmq_read_grouped, pgmq_read_grouped_head, pgmq_read_grouped_rr,
-    pgmq_send, pgmq_send_batch, pgmq_set_vt,
+    pgmq_archive, pgmq_bind_topic, pgmq_create, pgmq_create_fifo_index,
+    pgmq_create_fifo_indexes_all, pgmq_delete, pgmq_list_topic_bindings,
+    pgmq_list_topic_bindings_all, pgmq_pop, pgmq_read, pgmq_read_grouped, pgmq_read_grouped_head,
+    pgmq_read_grouped_rr, pgmq_send, pgmq_send_batch, pgmq_send_batch_topic, pgmq_send_topic,
+    pgmq_set_vt, pgmq_unbind_topic,
 };
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
@@ -127,4 +129,49 @@ pub fn read_grouped_rr_query(
         visibility_timeout,
         quantity,
     ))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn bind_topic_query<'p, 'q>(pattern: &'p str, queue_name: QueueName<'q>) -> _ {
+    let queue_name: &'q str = *queue_name;
+    select(pgmq_bind_topic(pattern, queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn unbind_topic_query<'p, 'q>(pattern: &'p str, queue_name: QueueName<'q>) -> _ {
+    let queue_name: &'q str = *queue_name;
+    select(pgmq_unbind_topic(pattern, queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn list_topic_bindings_query(queue_name: QueueName<'_>) -> _ {
+    let queue_name: &str = *queue_name;
+    select(pgmq_list_topic_bindings(queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn list_topic_bindings_all_query() -> _ {
+    select(pgmq_list_topic_bindings_all())
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn send_topic_query(
+    routing_key: &str,
+    message: serde_json::Value,
+    headers: serde_json::Value,
+    delay: VisibilityTimeoutOffset,
+) -> _ {
+    let delay: i32 = *delay;
+    select(pgmq_send_topic(routing_key, message, headers, delay))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn send_batch_topic_query(
+    routing_key: &str,
+    messages: Vec<serde_json::Value>,
+    headers: Option<Vec<serde_json::Value>>,
+    delay: VisibilityTimeoutOffset,
+) -> _ {
+    let delay: i32 = *delay;
+    select(pgmq_send_batch_topic(routing_key, messages, headers, delay))
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -59,6 +59,46 @@ where
     }
 }
 
+type PgListTopicBindingsRow = diesel::sql_types::Record<(
+    // pattern
+    Text,
+    // queue_name
+    Text,
+    // bound_at
+    Timestamptz,
+    // compiled_regex
+    Text,
+)>;
+
+impl FromSql<PgListTopicBindingsRow, Pg> for crate::types::ListTopicBindingsRow {
+    fn from_sql(bytes: PgValue) -> diesel::deserialize::Result<Self> {
+        let (pattern, queue_name, bound_at, compiled_regex) =
+            FromSql::<PgListTopicBindingsRow, Pg>::from_sql(bytes)?;
+
+        Ok(Self {
+            pattern,
+            queue_name,
+            bound_at,
+            compiled_regex,
+        })
+    }
+}
+
+type PgSendBatchTopicRow = diesel::sql_types::Record<(
+    // queue_name
+    Text,
+    // msg_id
+    BigInt,
+)>;
+
+impl FromSql<PgSendBatchTopicRow, Pg> for crate::types::SendBatchTopicRow {
+    fn from_sql(bytes: PgValue) -> diesel::deserialize::Result<Self> {
+        let (queue_name, msg_id) = FromSql::<PgSendBatchTopicRow, Pg>::from_sql(bytes)?;
+
+        Ok(Self { queue_name, msg_id })
+    }
+}
+
 #[declare_sql_function]
 extern "SQL" {
     #[sql_name = "pgmq.create"]
@@ -104,4 +144,27 @@ extern "SQL" {
 
     #[sql_name = "pgmq.read_grouped_rr"]
     fn pgmq_read_grouped_rr(queue_name: Text, vt: Integer, qty: Integer) -> PgMessage;
+
+    #[sql_name = "pgmq.bind_topic"]
+    fn pgmq_bind_topic(pattern: Text, queue_name: Text);
+
+    #[sql_name = "pgmq.unbind_topic"]
+    fn pgmq_unbind_topic(pattern: Text, queue_name: Text);
+
+    #[sql_name = "pgmq.list_topic_bindings"]
+    fn pgmq_list_topic_bindings(queue_name: Text) -> PgListTopicBindingsRow;
+
+    #[sql_name = "pgmq.list_topic_bindings"]
+    fn pgmq_list_topic_bindings_all() -> PgListTopicBindingsRow;
+
+    #[sql_name = "pgmq.send_topic"]
+    fn pgmq_send_topic(routing_key: Text, msg: Jsonb, headers: Jsonb, delay: Integer) -> Integer;
+
+    #[sql_name = "pgmq.send_batch_topic"]
+    fn pgmq_send_batch_topic(
+        routing_key: Text,
+        msgs: Array<Jsonb>,
+        headers: Nullable<Array<Jsonb>>,
+        delay: Integer,
+    ) -> PgSendBatchTopicRow;
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -321,6 +321,95 @@ macro_rules! impl_queue {
                 )
                 .await
             }
+
+            async fn bind_topic<'q, Q, QE>(
+                self,
+                pattern: &str,
+                queue_name: Q,
+            ) -> Result<(), crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                bind_topic($transform_self!(self), pattern, queue_name).await
+            }
+
+            async fn unbind_topic<'q, Q, QE>(
+                self,
+                pattern: &str,
+                queue_name: Q,
+            ) -> Result<(), crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                unbind_topic($transform_self!(self), pattern, queue_name).await
+            }
+
+            async fn list_topic_bindings<'q, Q, QE>(
+                self,
+                queue_name: Q,
+            ) -> Result<Vec<crate::types::ListTopicBindingsRow>, crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                list_topic_bindings($transform_self!(self), queue_name).await
+            }
+
+            async fn list_topic_bindings_all(
+                self,
+            ) -> Result<Vec<crate::types::ListTopicBindingsRow>, crate::PgmqError> {
+                list_topic_bindings_all($transform_self!(self)).await
+            }
+
+            async fn send_topic<T, H, D>(
+                self,
+                routing_key: &str,
+                message: T,
+                headers: H,
+                delay: D,
+            ) -> Result<i32, crate::PgmqError>
+            where
+                T: Send + serde::Serialize,
+                H: Send + serde::Serialize,
+                D: Send + Into<crate::types::VisibilityTimeoutOffset>,
+            {
+                let delay: crate::types::VisibilityTimeoutOffset = delay.into();
+                let message = serde_json::to_value(message)?;
+                let headers = serde_json::to_value(headers)?;
+                send_topic($transform_self!(self), routing_key, message, headers, delay).await
+            }
+
+            async fn send_batch_topic<'q, T, H, TI, HI, D>(
+                self,
+                routing_key: &str,
+                messages: TI,
+                headers: Option<HI>,
+                delay: D,
+            ) -> Result<Vec<crate::types::SendBatchTopicRow>, crate::PgmqError>
+            where
+                T: serde::Serialize,
+                H: serde::Serialize,
+                TI: Send + IntoIterator<Item = T>,
+                HI: Send + IntoIterator<Item = H>,
+                D: Send + Into<crate::types::VisibilityTimeoutOffset>,
+            {
+                let delay: crate::types::VisibilityTimeoutOffset = delay.into();
+                let messages = crate::util::serialize_list(messages)?;
+                let headers = crate::util::serialize_optional_list(headers)?;
+                send_batch_topic(
+                    $transform_self!(self),
+                    routing_key,
+                    messages,
+                    headers,
+                    delay,
+                )
+                .await
+            }
         }
     };
 }

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -501,4 +501,162 @@ pub trait Queue: crate::private::Sealed {
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: Into<crate::types::queue_name::QueueNameError>,
         VT: Send + Into<VisibilityTimeoutOffset>;
+
+    /// Bind a topic pattern to a queue. Messages matching the pattern will be routed to this queue when
+    /// they're sent with [`Self::send_topic`] or [`Self::send_batch_topic`].
+    ///
+    /// Invokes the `pgmq.bind_topic` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// queue.bind_topic("topic.*", "my_queue").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn bind_topic<'q, Q, QE>(self, pattern: &str, queue_name: Q) -> Result<(), PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Remove the topic pattern binding from the queue.
+    ///
+    /// Invokes the `pgmq.unbind_topic` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// queue.unbind_topic("topic.*", "my_queue").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn unbind_topic<'q, Q, QE>(self, pattern: &str, queue_name: Q) -> Result<(), PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Returns all topic bindings for the specified `queue_name`.
+    ///
+    /// Invokes the `pgmq.list_topic_bindings` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// let topic_bindings = queue.list_topic_bindings("my_queue").await?;
+    /// println!("{topic_bindings:?}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn list_topic_bindings<'q, Q, QE>(
+        self,
+        queue_name: Q,
+    ) -> Result<Vec<crate::types::ListTopicBindingsRow>, PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Returns all topic bindings across all queues.
+    ///
+    /// Invokes the `pgmq.list_topic_bindings` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// let topic_bindings = queue.list_topic_bindings_all().await?;
+    /// println!("{topic_bindings:?}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn list_topic_bindings_all(
+        self,
+    ) -> Result<Vec<crate::types::ListTopicBindingsRow>, PgmqError>;
+
+    /// Send a message using topic-based routing. Will send the message to every queue that has
+    /// a topic binding that matches the given `routing_key`. Returns the number of queues that
+    /// the message was sent to. If the message ID and/or queues the message was sent to are needed,
+    /// use [`Self::send_batch_topic`] instead.
+    ///
+    /// Invokes the `pgmq.send_topic` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// // Send an owned message with no headers and no delay
+    /// let msg = serde_json::json!({"a": 1234});
+    /// queue.send_topic("topic", msg, (), 0).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// // Send a message reference with headers and a delay
+    /// let msg = serde_json::json!({"a": 1234});
+    /// queue.send_topic("topic", &msg, serde_json::json!({"headerA": 5678}), 10).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn send_topic<T, H, D>(
+        self,
+        routing_key: &str,
+        message: T,
+        headers: H,
+        delay: D,
+    ) -> Result<i32, PgmqError>
+    where
+        T: Send + serde::Serialize,
+        H: Send + serde::Serialize,
+        D: Send + Into<VisibilityTimeoutOffset>;
+
+    /// Send multiple messages using topic-based routing. Will send the messages to every queue
+    /// that has a topic binding that matches the given `routing_key`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// // Send owned messages with no headers and no delay
+    /// let msgs = [serde_json::json!({"a": 1}), serde_json::json!({"a": 2})];
+    /// queue.send_batch_topic("topic", msgs, EMPTY_HEADERS, 0).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// // Send a slice of messages with headers and a delay
+    /// let msgs = [serde_json::json!({"a": 1}), serde_json::json!({"a": 2})];
+    /// let headers = [serde_json::json!({"headerA": 3}), serde_json::json!({"headerA": 4})];
+    /// queue.send_batch_topic("topic", &msgs, Some(&headers), Duration::from_secs(10)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn send_batch_topic<'q, T, H, TI, HI, D>(
+        self,
+        routing_key: &str,
+        messages: TI,
+        headers: Option<HI>,
+        delay: D,
+    ) -> Result<Vec<crate::types::SendBatchTopicRow>, PgmqError>
+    where
+        T: serde::Serialize,
+        H: serde::Serialize,
+        TI: Send + IntoIterator<Item = T>,
+        HI: Send + IntoIterator<Item = H>,
+        D: Send + Into<VisibilityTimeoutOffset>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -30,6 +30,30 @@ where
     }
 }
 
+impl TryFrom<::tokio_postgres::Row> for crate::types::ListTopicBindingsRow {
+    type Error = ::tokio_postgres::Error;
+
+    fn try_from(value: ::tokio_postgres::Row) -> Result<Self, Self::Error> {
+        Ok(Self {
+            pattern: value.try_get("pattern")?,
+            queue_name: value.try_get("queue_name")?,
+            bound_at: value.try_get("bound_at")?,
+            compiled_regex: value.try_get("compiled_regex")?,
+        })
+    }
+}
+
+impl TryFrom<::tokio_postgres::Row> for crate::types::SendBatchTopicRow {
+    type Error = ::tokio_postgres::Error;
+
+    fn try_from(value: ::tokio_postgres::Row) -> Result<Self, Self::Error> {
+        Ok(Self {
+            queue_name: value.try_get("queue_name")?,
+            msg_id: value.try_get("msg_id")?,
+        })
+    }
+}
+
 type SqlParam<'a> = (&'a (dyn postgres_types::ToSql + Sync), postgres_types::Type);
 
 /// This macro defines all the functions required to implement [`crate::queue::Queue`] for both
@@ -323,6 +347,119 @@ macro_rules! rust_postgres_functions {
             rows.into_iter()
                 .map(|row| crate::Message::<T, H>::try_from(row))
                 .collect::<Result<Vec<crate::Message<T, H>>, crate::PgmqError>>()
+        }
+
+        async fn bind_topic<C>(
+            executor: $ref_type!(C),
+            pattern: &str,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&pattern, postgres_types::Type::TEXT),
+                (&*queue_name, postgres_types::Type::TEXT),
+            ];
+            let result = executor.execute_typed(crate::queue::sql::BIND_TOPIC, &params);
+            $transform_result!(result)?;
+            Ok(())
+        }
+
+        async fn unbind_topic<C>(
+            executor: $ref_type!(C),
+            pattern: &str,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&pattern, postgres_types::Type::TEXT),
+                (&*queue_name, postgres_types::Type::TEXT),
+            ];
+            let result = executor.execute_typed(crate::queue::sql::UNBIND_TOPIC, &params);
+            $transform_result!(result)?;
+            Ok(())
+        }
+
+        async fn list_topic_bindings<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<Vec<crate::types::ListTopicBindingsRow>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] =
+                [(&*queue_name, postgres_types::Type::TEXT)];
+            let rows = executor.query_typed(crate::queue::sql::LIST_TOPIC_BINDINGS, &params);
+            let rows = $transform_result!(rows)?;
+            let rows = rows
+                .into_iter()
+                .map(|row| crate::types::ListTopicBindingsRow::try_from(row))
+                .collect::<Result<Vec<crate::types::ListTopicBindingsRow>, _>>()?;
+            Ok(rows)
+        }
+
+        async fn list_topic_bindings_all<C>(
+            executor: $ref_type!(C),
+        ) -> Result<Vec<crate::types::ListTopicBindingsRow>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let rows = executor.query_typed(crate::queue::sql::LIST_TOPIC_BINDINGS_ALL, &[]);
+            let rows = $transform_result!(rows)?;
+            let rows = rows
+                .into_iter()
+                .map(|row| crate::types::ListTopicBindingsRow::try_from(row))
+                .collect::<Result<Vec<crate::types::ListTopicBindingsRow>, _>>()?;
+            Ok(rows)
+        }
+
+        async fn send_topic<C>(
+            executor: $ref_type!(C),
+            routing_key: &str,
+            message: serde_json::Value,
+            headers: serde_json::Value,
+            delay: crate::types::VisibilityTimeoutOffset,
+        ) -> Result<i32, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&routing_key, postgres_types::Type::TEXT),
+                (&message, postgres_types::Type::JSONB),
+                (&headers, postgres_types::Type::JSONB),
+                (&*delay, postgres_types::Type::INT4),
+            ];
+            let row = executor.query_typed_one(crate::queue::sql::SEND_TOPIC, &params);
+            let row = $transform_result!(row)?;
+            Ok(row.try_get(0)?)
+        }
+
+        async fn send_batch_topic<C>(
+            executor: $ref_type!(C),
+            routing_key: &str,
+            messages: Vec<serde_json::Value>,
+            headers: Option<Vec<serde_json::Value>>,
+            delay: crate::types::VisibilityTimeoutOffset,
+        ) -> Result<Vec<crate::types::SendBatchTopicRow>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&routing_key, postgres_types::Type::TEXT),
+                (&messages, postgres_types::Type::JSONB_ARRAY),
+                (&headers, postgres_types::Type::JSONB_ARRAY),
+                (&*delay, postgres_types::Type::INT4),
+            ];
+            let rows = executor.query_typed(crate::queue::sql::SEND_BATCH_TOPIC, &params);
+            let rows = $transform_result!(rows)?;
+            let rows = rows
+                .into_iter()
+                .map(|row| crate::types::SendBatchTopicRow::try_from(row))
+                .collect::<Result<Vec<crate::types::SendBatchTopicRow>, _>>()?;
+            Ok(rows)
         }
     };
 }

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -41,3 +41,22 @@ pub const READ_GROUPED_HEAD: &str = "SELECT msg_id, read_ct, enqueued_at, last_r
 
 // language=PostgreSQL
 pub const READ_GROUPED_RR: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers FROM pgmq.read_grouped_rr(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)";
+
+// language=PostgreSQL
+pub const BIND_TOPIC: &str = "SELECT pgmq.bind_topic(pattern=>$1::text, queue_name=>$2::text)";
+
+// language=PostgreSQL
+pub const UNBIND_TOPIC: &str = "SELECT pgmq.unbind_topic(pattern=>$1::text, queue_name=>$2::text)";
+
+// language=PostgreSQL
+pub const LIST_TOPIC_BINDINGS: &str = "SELECT pattern, queue_name, bound_at, compiled_regex from pgmq.list_topic_bindings(queue_name=>$1::text)";
+
+// language=PostgreSQL
+pub const LIST_TOPIC_BINDINGS_ALL: &str =
+    "SELECT pattern, queue_name, bound_at, compiled_regex from pgmq.list_topic_bindings()";
+
+// language=PostgreSQL
+pub const SEND_TOPIC: &str = "SELECT * from pgmq.send_topic(routing_key=>$1::text, msg=>$2::jsonb, headers=>$3::jsonb, delay=>$4::int)";
+
+// language=PostgreSQL
+pub const SEND_BATCH_TOPIC: &str = "SELECT queue_name, msg_id from pgmq.send_batch_topic(routing_key=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer)";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,11 +1,12 @@
 use crate::queue::macros::{identity_macro, impl_queue};
 use crate::queue::sql::{
-    ARCHIVE, CREATE, CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, DELETE, POP, READ, READ_GROUPED,
-    READ_GROUPED_HEAD, READ_GROUPED_RR, SEND, SEND_BATCH, SET_VT,
+    ARCHIVE, BIND_TOPIC, CREATE, CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, DELETE,
+    LIST_TOPIC_BINDINGS, LIST_TOPIC_BINDINGS_ALL, POP, READ, READ_GROUPED, READ_GROUPED_HEAD,
+    READ_GROUPED_RR, SEND, SEND_BATCH, SEND_BATCH_TOPIC, SEND_TOPIC, SET_VT, UNBIND_TOPIC,
 };
-use crate::types::{QueueName, VisibilityTimeoutOffset};
+use crate::types::{ListTopicBindingsRow, QueueName, SendBatchTopicRow, VisibilityTimeoutOffset};
 use crate::{Message, PgmqError};
-use sqlx::{Executor, Postgres};
+use sqlx::{Executor, FromRow, Postgres};
 use util::handle_read_batch_result;
 
 pub(crate) mod util;
@@ -274,4 +275,118 @@ where
         .await?;
 
     handle_read_batch_result(rows)
+}
+
+pub(crate) async fn bind_topic<'c, C>(
+    executor: C,
+    pattern: &str,
+    queue_name: QueueName<'_>,
+) -> Result<(), PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    sqlx::query(BIND_TOPIC)
+        .bind(pattern)
+        .bind(*queue_name)
+        .execute(executor)
+        .await?;
+    Ok(())
+}
+
+pub(crate) async fn unbind_topic<'c, C>(
+    executor: C,
+    pattern: &str,
+    queue_name: QueueName<'_>,
+) -> Result<(), PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    sqlx::query(UNBIND_TOPIC)
+        .bind(pattern)
+        .bind(*queue_name)
+        .execute(executor)
+        .await?;
+    Ok(())
+}
+
+pub(crate) async fn list_topic_bindings<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+) -> Result<Vec<ListTopicBindingsRow>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let query = sqlx::query(LIST_TOPIC_BINDINGS).bind(*queue_name);
+    list_topic_bindings_common(executor, query).await
+}
+
+pub(crate) async fn list_topic_bindings_all<'c, C>(
+    executor: C,
+) -> Result<Vec<ListTopicBindingsRow>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let query = sqlx::query(LIST_TOPIC_BINDINGS_ALL);
+    list_topic_bindings_common(executor, query).await
+}
+
+async fn list_topic_bindings_common<'q, 'c, C>(
+    executor: C,
+    query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments>,
+) -> Result<Vec<ListTopicBindingsRow>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let rows = query.fetch_all(executor).await?;
+    let rows = rows
+        .into_iter()
+        .map(|row| ListTopicBindingsRow::from_row(&row))
+        .collect::<Result<Vec<ListTopicBindingsRow>, _>>()?;
+    Ok(rows)
+}
+
+pub(crate) async fn send_topic<'c, C>(
+    executor: C,
+    routing_key: &str,
+    message: serde_json::Value,
+    headers: serde_json::Value,
+    delay: VisibilityTimeoutOffset,
+) -> Result<i32, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let matched_queue_count: i32 = sqlx::query_scalar(SEND_TOPIC)
+        .bind(routing_key)
+        .bind(message)
+        .bind(headers)
+        .bind(delay)
+        .fetch_one(executor)
+        .await?;
+    Ok(matched_queue_count)
+}
+
+pub(crate) async fn send_batch_topic<'c, C>(
+    executor: C,
+    routing_key: &str,
+    messages: Vec<serde_json::Value>,
+    headers: Option<Vec<serde_json::Value>>,
+    delay: VisibilityTimeoutOffset,
+) -> Result<Vec<SendBatchTopicRow>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let sent = sqlx::query(SEND_BATCH_TOPIC)
+        .bind(routing_key)
+        .bind(messages)
+        .bind(headers)
+        .bind(delay)
+        .fetch_all(executor)
+        .await?;
+
+    let sent = sent
+        .into_iter()
+        .map(|row| SendBatchTopicRow::from_row(&row))
+        .collect::<Result<Vec<SendBatchTopicRow>, _>>()?;
+
+    Ok(sent)
 }

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -236,6 +236,17 @@ async fn create_invalid_character(conn_details: ConnDetails, queue: impl Queue) 
 }
 
 #[pgmq_test_macro::queue_test]
+async fn send_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result = queue.send("invalid-queue-name", (), (), 0).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
 async fn read(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
     let msg = TestMessage::new();
@@ -807,4 +818,124 @@ async fn read_grouped_rr_diff_groups(conn_details: ConnDetails, queue: impl Queu
         read_msgs.first().unwrap().message.b,
         read_msgs.get(1).unwrap().message.b
     );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn bind_topic_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<_, _> = queue.bind_topic("pattern", "invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn unbind_topic_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<_, _> = queue.unbind_topic("pattern", "invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn list_topic_bindings_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<_, _> = queue.list_topic_bindings("invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn bind_and_list_topics(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let pattern = format!("{QUEUE}.*");
+
+    queue.bind_topic(&pattern, QUEUE).await.unwrap();
+    let topic_binding = queue
+        .list_topic_bindings(QUEUE)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    assert!(topic_binding.is_some());
+    let topic_binding = topic_binding.unwrap();
+    assert_eq!(topic_binding.queue_name, QUEUE);
+    assert_eq!(topic_binding.pattern, pattern);
+    assert_eq!(topic_binding.compiled_regex, format!("^{QUEUE}\\.[^.]+$"));
+}
+
+#[pgmq_test_macro::queue_test]
+async fn bind_and_list_topics_all(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let pattern = format!("{QUEUE}.*");
+
+    queue.bind_topic(&pattern, QUEUE).await.unwrap();
+    let topic_bindings = queue.list_topic_bindings_all().await.unwrap();
+    let topic_binding = topic_bindings
+        .into_iter()
+        .find(|binding| binding.queue_name == QUEUE)
+        .unwrap();
+    assert_eq!(topic_binding.queue_name, QUEUE);
+    assert_eq!(topic_binding.pattern, pattern);
+    assert_eq!(topic_binding.compiled_regex, format!("^{QUEUE}\\.[^.]+$"));
+}
+
+#[pgmq_test_macro::queue_test]
+async fn unbind_topic(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let pattern = format!("{QUEUE}.*");
+
+    queue.bind_topic(&pattern, QUEUE).await.unwrap();
+    queue.unbind_topic(&pattern, QUEUE).await.unwrap();
+    let topic_binding = queue
+        .list_topic_bindings(QUEUE)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    assert!(topic_binding.is_none());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn send_topic(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let pattern = format!("{QUEUE}.*");
+
+    queue.bind_topic(&pattern, QUEUE).await.unwrap();
+
+    let msg = TestMessage::new();
+    let matched_queues = queue
+        .send_topic(&format!("{QUEUE}.foo"), &msg, Option::<&()>::None, 0)
+        .await
+        .unwrap();
+    assert_eq!(1, matched_queues);
+
+    let read_msg: Vec<Message<TestMessage>> = queue.read(QUEUE, 100, 1).await.unwrap();
+    assert!(!read_msg.is_empty());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn send_batch_topic(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let pattern = format!("{QUEUE}.*");
+
+    queue.bind_topic(&pattern, QUEUE).await.unwrap();
+
+    let msgs = [TestMessage::new(), TestMessage::new()];
+    let send_batch_rows = queue
+        .send_batch_topic(&format!("{QUEUE}.foo"), &msgs, EMPTY_HEADERS, 0)
+        .await
+        .unwrap();
+    assert_eq!(msgs.len(), send_batch_rows.len());
+
+    let read_msgs: Vec<Message<TestMessage>> = queue.read(QUEUE, 100, 2).await.unwrap();
+    assert_eq!(msgs.len(), read_msgs.len());
 }


### PR DESCRIPTION
This PR adds `bind_topic`, `unbind_topic`, `list_topic_bindings`, `list_topic_bindings_all`, `send_topic`, and `send_batch_topic` methods to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres). This PR also updates the relevant methods in `PGMQueueExt` to use the sqlx implementation of `Queue`.

The new tests in `tests/queue.rs` were copied from the existing tests in `pg_ext_integration_test.rs` and translated to use the `Queue` trait methods.

Relates to https://github.com/pgmq/pgmq/issues/425