### PR TITLE
feat: Add transaction trait and `acquire_queue_lock` method

### DIFF
--- a/pgmq-rs/pgmq_test_macro/src/lib.rs
+++ b/pgmq-rs/pgmq_test_macro/src/lib.rs
@@ -1,7 +1,7 @@
 //! Private macro(s) used by the `pgmq` crate in tests.
 
 use quote::quote;
-use syn::{Item, parse_macro_input};
+use syn::{Item, ItemFn, parse_macro_input};
 
 /// This attribute macro is only intended to be used to help generate tests for each implementation
 /// of the `pgmq::Queue` trait.
@@ -31,6 +31,54 @@ pub fn queue_test(
         _ => panic!("This macro only supports functions"),
     };
 
+    // Create individual test functions using the test details for each client implementation.
+    let test_functions = build_queue_tests(&item)
+        .into_iter()
+        // Include the tests that execute inside a transaction
+        .chain(build_queue_transaction_tests(&item).into_iter());
+
+    // Collect all the test functions into a single token stream.
+    test_functions.collect::<proc_macro2::TokenStream>().into()
+}
+
+/// This attribute macro is only intended to be used to help generate tests for each implementation
+/// of the `pgmq::QueueTransaction` trait.
+///
+/// The macro can be placed on a method that takes `conn_details: ConnDetails` and
+/// `queue: impl QueueTransaction` parameters. Since this macro is only intended to be used in the
+/// `QueueTransaction` trait integration tests, it makes some assumptions about utility
+/// types/functions that it needs to be in scope. For example, it expects the `ConnDetails` struct
+/// to be in scope, as well as functions to create connections and/or connection pools for each
+/// client that implements `QueueTransaction`, and `before`/`after` functions to perform
+/// setup/teardown logic that's shared between all tests.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[pgmq_test_macro::queue_transaction_test]
+/// async fn acquire_queue_lock(conn_details: ConnDetails, queue: impl Queue) {
+///     queue.acquire_queue_lock("queue").await.unwrap();
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn queue_transaction_test(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let item = match parse_macro_input!(item as Item) {
+        Item::Fn(item) => item,
+        _ => panic!("This macro only supports functions"),
+    };
+
+    // Collect all the test functions into a single token stream.
+    build_queue_transaction_tests(&item)
+        .into_iter()
+        .collect::<proc_macro2::TokenStream>()
+        .into()
+}
+
+/// Builds the test functions for all types that only implement `Queue` and not `QueueTransaction`
+fn build_queue_tests(original_fn: &ItemFn) -> impl IntoIterator<Item = proc_macro2::TokenStream> {
     /*
     Because the `Queue` trait's methods all take `self`, only a single method can be called in a
     method that takes `impl Queue`. Example:
@@ -49,7 +97,7 @@ pub fn queue_test(
     methods, and the block will compile with multiple method calls because the `queue` variable
     is a reference.
      */
-    let original_block = &item.block;
+    let original_block = &original_fn.block;
 
     let test_details = [
         (
@@ -87,20 +135,6 @@ pub fn queue_test(
         ),
         (
             "sqlx",
-            "sqlx_txn",
-            quote! {
-                use sqlx::Connection;
-                let mut conn = initialization::sqlx_conn(&conn_details.test_db_url).await;
-                let mut transaction = conn.begin().await.unwrap();
-                let queue = &mut transaction;
-
-                #original_block
-
-                transaction.commit().await.unwrap();
-            },
-        ),
-        (
-            "sqlx",
             "sqlx_pool",
             quote! {
                 let pool = pgmq::util::connect(conn_details.test_db_url.as_str(), 2)
@@ -133,25 +167,6 @@ pub fn queue_test(
             },
         ),
         (
-            "rust-postgres",
-            "rp_txn",
-            quote! {
-                {
-                    let conn_details = conn_details.clone();
-                    tokio::task::spawn_blocking(move || {
-                        tokio::runtime::Handle::current()
-                            .block_on(async {
-                                let mut client = initialization::rust_postgres(&conn_details.test_db_url);
-                                let mut transaction = client.transaction().unwrap();
-                                let queue = &mut transaction;
-                                #original_block
-                                transaction.commit().unwrap();
-                            });
-                    });
-                }
-            },
-        ),
-        (
             "tokio-postgres",
             "tp_client",
             quote! {
@@ -164,45 +179,12 @@ pub fn queue_test(
             },
         ),
         (
-            "tokio-postgres",
-            "tp_txn",
-            quote! {
-                let (mut client, conn) = initialization::tokio_postgres(&conn_details.test_db_url).await;
-                tokio::spawn(async move {
-                    conn.await.unwrap();
-                });
-                let transaction = client.transaction().await.unwrap();
-                let queue = &transaction;
-
-                #original_block
-
-                transaction.commit().await.unwrap();
-            },
-        ),
-        (
             "diesel-sync",
             "d_conn",
             quote! {
                 let mut conn = initialization::diesel_conn(&conn_details.test_db_url);
                 let queue = &mut conn;
                 #original_block
-            },
-        ),
-        (
-            "diesel-sync",
-            "d_txn",
-            quote! {
-                use diesel::Connection;
-                let mut conn = initialization::diesel_conn(&conn_details.test_db_url);
-                tokio::task::spawn_blocking(move || {
-                    conn.transaction(|queue| -> Result<(), diesel::result::Error> {
-                        tokio::runtime::Handle::current()
-                            .block_on(async {
-                                #original_block
-                            });
-                        Ok(())
-                    }).unwrap();
-                });
             },
         ),
         (
@@ -234,19 +216,6 @@ pub fn queue_test(
             },
         ),
         (
-            "diesel-async",
-            "da_txn",
-            quote! {
-                use diesel_async::AsyncConnection;
-                let mut conn = initialization::diesel_async_conn(&conn_details.test_db_url).await;
-                conn.transaction(async |queue| -> Result<(), diesel::result::Error> {
-                    #original_block
-
-                    Ok(())
-                }).await.unwrap();
-            },
-        ),
-        (
             "diesel-async-pool",
             "da_pool",
             quote! {
@@ -268,11 +237,110 @@ pub fn queue_test(
     ];
 
     // Create individual test functions using the test details for each client implementation.
-    let test_functions = test_details
+    build_test_functions(&original_fn, test_details)
+}
+
+/// Builds the test functions for types that implement `QueueTransaction` and to need to run inside
+/// a transaction.
+fn build_queue_transaction_tests(
+    original_fn: &ItemFn,
+) -> impl IntoIterator<Item = proc_macro2::TokenStream> {
+    let original_block = &original_fn.block;
+    let test_details = [
+        (
+            "sqlx",
+            "sqlx_txn",
+            quote! {
+                use sqlx::Connection;
+                let mut conn = initialization::sqlx_conn(&conn_details.test_db_url).await;
+                let mut transaction = conn.begin().await.unwrap();
+                let queue = &mut transaction;
+
+                #original_block
+
+                transaction.commit().await.unwrap();
+            },
+        ),
+        (
+            "rust-postgres",
+            "rp_txn",
+            quote! {
+                {
+                    let conn_details = conn_details.clone();
+                    tokio::task::spawn_blocking(move || {
+                        tokio::runtime::Handle::current()
+                            .block_on(async {
+                                let mut client = initialization::rust_postgres(&conn_details.test_db_url);
+                                let mut transaction = client.transaction().unwrap();
+                                let queue = &mut transaction;
+                                #original_block
+                                transaction.commit().unwrap();
+                            });
+                    });
+                }
+            },
+        ),
+        (
+            "tokio-postgres",
+            "tp_txn",
+            quote! {
+                let (mut client, conn) = initialization::tokio_postgres(&conn_details.test_db_url).await;
+                tokio::spawn(async move {
+                    conn.await.unwrap();
+                });
+                let transaction = client.transaction().await.unwrap();
+                let queue = &transaction;
+
+                #original_block
+
+                transaction.commit().await.unwrap();
+            },
+        ),
+        (
+            "diesel-sync",
+            "d_txn",
+            quote! {
+                use diesel::Connection;
+                let mut conn = initialization::diesel_conn(&conn_details.test_db_url);
+                tokio::task::spawn_blocking(move || {
+                    conn.transaction(|queue| -> Result<(), diesel::result::Error> {
+                        tokio::runtime::Handle::current()
+                            .block_on(async {
+                                #original_block
+                            });
+                        Ok(())
+                    }).unwrap();
+                });
+            },
+        ),
+        (
+            "diesel-async",
+            "da_txn",
+            quote! {
+                use diesel_async::AsyncConnection;
+                let mut conn = initialization::diesel_async_conn(&conn_details.test_db_url).await;
+                conn.transaction(async |queue| -> Result<(), diesel::result::Error> {
+                    #original_block
+
+                    Ok(())
+                }).await.unwrap();
+            },
+        ),
+    ];
+
+    // Create individual test functions using the test details for each client implementation.
+    build_test_functions(&original_fn, test_details)
+}
+
+fn build_test_functions<'a>(
+    original_fn: &ItemFn,
+    test_details: impl IntoIterator<Item = (&'a str, &'a str, proc_macro2::TokenStream)>,
+) -> impl IntoIterator<Item = proc_macro2::TokenStream> {
+    test_details
         .into_iter()
         .map(|(feature, impl_type, invoke)| {
             let test_name = syn::Ident::new(
-                &format!("{}_{}", item.sig.ident, impl_type),
+                &format!("{}_{}", original_fn.sig.ident, impl_type),
                 proc_macro2::Span::call_site(),
             );
             quote! {
@@ -280,15 +348,15 @@ pub fn queue_test(
                 #[tokio::test]
                 async fn #test_name() {
                     let conn_details = ConnDetails::new();
+                    // Clone the `conn_details` to use in the `after` hook because some test
+                    // impls may perform a partial move of the original value.
+                    let conn_details_cloned = conn_details.clone();
                     initialization::before(&conn_details).await;
 
                     #invoke
 
-                    initialization::after(&conn_details).await;
+                    initialization::after(&conn_details_cloned).await;
                 }
             }
-        });
-
-    // Collect all the test functions into a single token stream.
-    test_functions.collect::<proc_macro2::TokenStream>().into()
+        })
 }

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1,7 +1,7 @@
 use crate::errors::PgmqError;
 use crate::queue::sql::READ;
 use crate::queue::sqlx::util::handle_read_batch_result;
-use crate::queue::Queue;
+use crate::queue::{Queue, QueueTransaction};
 use crate::types::queue_name::check_queue_name;
 use crate::types::{
     ListNotifyInsertThrottlesRow, ListTopicBindingsRow, Message, PGMQueueMeta, QueueMetrics,
@@ -176,17 +176,13 @@ impl PGMQueueExt {
         queue_name: &str,
         txn: &mut sqlx::Transaction<'c, Postgres>,
     ) -> Result<(), PgmqError> {
-        check_queue_name(queue_name)?;
-        sqlx::query("SELECT pgmq.acquire_queue_lock(queue_name=>$1::text);")
-            .bind(queue_name)
-            .execute(&mut **txn)
-            .await?;
-        Ok(())
+        let queue_name: QueueName = queue_name.try_into()?;
+        txn.acquire_queue_lock(queue_name).await
     }
 
     /// Acquire a transaction-level advisory lock specific to the provided queue. Useful to prevent
     /// race conditions when performing queue/table-level operations, such as creating an index
-    /// for the queue (e.g., with [`Self::create_fifo_index`].
+    /// for the queue (e.g., with [`Self::create_fifo_index`]).
     ///
     /// Returns the [`sqlx::Transaction`] that should be used to perform the queue/table-level
     /// operations. Remember to call [`sqlx::Transaction::commit`] after performing the desired

--- a/pgmq-rs/src/queue/diesel/diesel_async.rs
+++ b/pgmq-rs/src/queue/diesel/diesel_async.rs
@@ -1,5 +1,7 @@
 use crate::queue::diesel::diesel_functions;
-use crate::queue::macros::{identity_macro, impl_queue, transform_result_async};
+use crate::queue::macros::{
+    identity_macro, impl_queue, impl_queue_transaction, transform_result_async,
+};
 
 diesel_functions!(
     diesel_async::AsyncConnection<Backend = diesel::pg::Pg>,
@@ -7,7 +9,10 @@ diesel_functions!(
     transform_result_async
 );
 
-impl_queue!(&mut diesel_async::AsyncPgConnection, identity_macro);
+// `diesel`/`diesel-async` don't have a type specific to transactions. Instead, transactions
+// are performed in a callback provided to a `transaction` method, where the callback gets a
+// reference to the connection. So, we need to implement `QueueTransaction` for the connection type.
+impl_queue_transaction!(&mut diesel_async::AsyncPgConnection, identity_macro);
 
 #[cfg(feature = "diesel-async-pool")]
 macro_rules! transform_self_acquire_connection_async {

--- a/pgmq-rs/src/queue/diesel/diesel_sync.rs
+++ b/pgmq-rs/src/queue/diesel/diesel_sync.rs
@@ -1,5 +1,5 @@
 use crate::queue::diesel::diesel_functions;
-use crate::queue::macros::{identity_macro, impl_queue};
+use crate::queue::macros::{identity_macro, impl_queue, impl_queue_transaction};
 
 diesel_functions!(
     diesel::connection::LoadConnection<Backend = diesel::pg::Pg>,
@@ -7,7 +7,10 @@ diesel_functions!(
     identity_macro
 );
 
-impl_queue!(&mut diesel::PgConnection, identity_macro);
+// `diesel`/`diesel-async` don't have a type specific to transactions. Instead, transactions
+// are performed in a callback provided to a `transaction` method, where the callback gets a
+// reference to the connection. So, we need to implement `QueueTransaction` for the connection type.
+impl_queue_transaction!(&mut diesel::PgConnection, identity_macro);
 
 #[cfg(feature = "diesel-sync-pool")]
 macro_rules! transform_self_acquire_connection {

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -466,6 +466,19 @@ macro_rules! diesel_functions {
             let result = result.optional()?;
             Ok(result)
         }
+
+        async fn acquire_queue_lock<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result =
+                crate::queue::diesel::query::acquire_queue_lock_query(queue_name).execute(executor);
+            $transform_result!(result)?;
+            Ok(())
+        }
     };
 }
 

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,7 +1,7 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
 use crate::queue::diesel::sql::{
-    pgmq_archive, pgmq_bind_topic, pgmq_convert_archive_partitioned, pgmq_create,
-    pgmq_create_fifo_index, pgmq_create_fifo_indexes_all, pgmq_create_partitioned,
+    pgmq_acquire_queue_lock, pgmq_archive, pgmq_bind_topic, pgmq_convert_archive_partitioned,
+    pgmq_create, pgmq_create_fifo_index, pgmq_create_fifo_indexes_all, pgmq_create_partitioned,
     pgmq_create_unlogged, pgmq_delete, pgmq_disable_notify_insert, pgmq_enable_notify_insert,
     pgmq_list_notify_insert_throttles, pgmq_list_queues, pgmq_list_topic_bindings,
     pgmq_list_topic_bindings_all, pgmq_pop, pgmq_read, pgmq_read_grouped, pgmq_read_grouped_head,
@@ -254,4 +254,10 @@ pub fn queue_metadata_query(queue_name: QueueName<'_>) -> _ {
     let queue_name: &str = *queue_name;
     crate::queue::diesel::schema::meta::table
         .filter(crate::queue::diesel::schema::meta::queue_name.eq(queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn acquire_queue_lock_query(queue_name: QueueName<'_>) -> _ {
+    let queue_name: &str = *queue_name;
+    select(pgmq_acquire_queue_lock(queue_name))
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -260,4 +260,7 @@ extern "SQL" {
 
     #[sql_name = "pgmq.list_queues"]
     fn pgmq_list_queues() -> PgPGMQueueMeta;
+
+    #[sql_name = "pgmq.acquire_queue_lock"]
+    fn pgmq_acquire_queue_lock(queue_name: Text);
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -530,3 +530,36 @@ macro_rules! impl_queue {
 }
 // Re-export the macro for use within this crate
 pub(crate) use impl_queue;
+
+/// Helper macro to implement the [`crate::queue::transaction::QueueTransaction`] trait for a type.
+/// This trait is similar to [`impl_queue`]; however, because
+/// [`crate::queue::transaction::QueueTransaction`] requires the type to implement
+/// [`crate::queue::Queue`], this macro also invokes [`impl_queue`] for the provided type, so
+/// only one of [`impl_queue`] and [`impl_queue_transaction`] should be invoked for a given type.
+macro_rules! impl_queue_transaction {
+    (
+        /// The type to implement the `Queue` trait for.
+        $for_type:ty,
+        /// Expression used to transform `self` into an implementation-specific executor type.
+        $transform_self:tt
+    ) => {
+        crate::queue::macros::impl_queue!($for_type, $transform_self);
+
+        #[async_trait::async_trait]
+        impl crate::queue::transaction::QueueTransaction for $for_type {
+            async fn acquire_queue_lock<'q, Q, QE>(
+                self,
+                queue_name: Q,
+            ) -> Result<(), crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                acquire_queue_lock($transform_self!(self), queue_name).await
+            }
+        }
+    };
+}
+// Re-export the macro for use within this crate
+pub(crate) use impl_queue_transaction;

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -15,12 +15,15 @@ pub mod rust_postgres;
 pub(crate) mod sql;
 #[cfg(feature = "sqlx")]
 pub mod sqlx;
+mod transaction;
 
 use crate::types::{
     InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, PGMQueueMeta, QueueName,
     VisibilityTimeoutOffset,
 };
 use crate::{Message, PgmqError};
+
+pub use transaction::QueueTransaction;
 
 /// Interface that provides methods for invoking PGMQ SQL functions.
 ///

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -609,6 +609,20 @@ macro_rules! rust_postgres_functions {
             };
             Ok(result)
         }
+
+        async fn acquire_queue_lock<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] =
+                [(&*queue_name, postgres_types::Type::TEXT)];
+            let result = executor.execute_typed(crate::queue::sql::ACQUIRE_QUEUE_LOCK, &params);
+            $transform_result!(result)?;
+            Ok(())
+        }
     };
 }
 pub(crate) use rust_postgres_functions;

--- a/pgmq-rs/src/queue/rust_postgres/postgres.rs
+++ b/pgmq-rs/src/queue/rust_postgres/postgres.rs
@@ -1,8 +1,8 @@
-use crate::queue::macros::{identity_macro, impl_queue};
+use crate::queue::macros::{identity_macro, impl_queue, impl_queue_transaction};
 use crate::queue::rust_postgres::rust_postgres_functions;
 
 impl_queue!(&mut postgres::Client, identity_macro);
-impl_queue!(&mut postgres::Transaction<'_>, identity_macro);
+impl_queue_transaction!(&mut postgres::Transaction<'_>, identity_macro);
 
 macro_rules! mutable_ref {
     ($type_:ty) => {

--- a/pgmq-rs/src/queue/rust_postgres/tokio_postgres.rs
+++ b/pgmq-rs/src/queue/rust_postgres/tokio_postgres.rs
@@ -1,8 +1,10 @@
-use crate::queue::macros::{identity_macro, impl_queue, transform_result_async};
+use crate::queue::macros::{
+    identity_macro, impl_queue, impl_queue_transaction, transform_result_async,
+};
 use crate::queue::rust_postgres::rust_postgres_functions;
 
 impl_queue!(&tokio_postgres::Client, identity_macro);
-impl_queue!(&tokio_postgres::Transaction<'_>, identity_macro);
+impl_queue_transaction!(&tokio_postgres::Transaction<'_>, identity_macro);
 
 macro_rules! immutable_ref {
     ($type_:ty) => {

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -96,3 +96,6 @@ pub(crate) const LIST_QUEUES: &str =
 // language=PostgreSQL
 pub(crate) const QUEUE_METADATA: &str =
     "SELECT queue_name, is_partitioned, is_unlogged, created_at FROM pgmq.meta WHERE queue_name = $1::text";
+
+// language=PostgreSQL
+pub(crate) const ACQUIRE_QUEUE_LOCK: &str = "SELECT pgmq.acquire_queue_lock(queue_name=>$1::text)";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,11 +1,11 @@
-use crate::queue::macros::{identity_macro, impl_queue};
+use crate::queue::macros::{identity_macro, impl_queue, impl_queue_transaction};
 use crate::queue::sql::{
-    ARCHIVE, BIND_TOPIC, CONVERT_ARCHIVE_PARTITIONED, CREATE, CREATE_FIFO_INDEX,
-    CREATE_FIFO_INDEXES_ALL, CREATE_PARTITIONED, CREATE_UNLOGGED, DELETE, DISABLE_NOTIFY_INSERT,
-    ENABLE_NOTIFY_INSERT, LIST_NOTIFY_INSERT_THROTTLES, LIST_QUEUES, LIST_TOPIC_BINDINGS,
-    LIST_TOPIC_BINDINGS_ALL, POP, QUEUE_METADATA, READ, READ_GROUPED, READ_GROUPED_HEAD,
-    READ_GROUPED_RR, SEND, SEND_BATCH, SEND_BATCH_TOPIC, SEND_TOPIC, SET_VT, UNBIND_TOPIC,
-    UPDATE_NOTIFY_INSERT,
+    ACQUIRE_QUEUE_LOCK, ARCHIVE, BIND_TOPIC, CONVERT_ARCHIVE_PARTITIONED, CREATE,
+    CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, CREATE_PARTITIONED, CREATE_UNLOGGED, DELETE,
+    DISABLE_NOTIFY_INSERT, ENABLE_NOTIFY_INSERT, LIST_NOTIFY_INSERT_THROTTLES, LIST_QUEUES,
+    LIST_TOPIC_BINDINGS, LIST_TOPIC_BINDINGS_ALL, POP, QUEUE_METADATA, READ, READ_GROUPED,
+    READ_GROUPED_HEAD, READ_GROUPED_RR, SEND, SEND_BATCH, SEND_BATCH_TOPIC, SEND_TOPIC, SET_VT,
+    UNBIND_TOPIC, UPDATE_NOTIFY_INSERT,
 };
 use crate::types::{
     InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, ListTopicBindingsRow,
@@ -25,7 +25,7 @@ macro_rules! transform_input_dereference_transaction {
     };
 }
 
-impl_queue!(
+impl_queue_transaction!(
     &mut sqlx::Transaction<'_, Postgres>,
     transform_input_dereference_transaction
 );
@@ -524,4 +524,18 @@ where
         .await?;
 
     Ok(metadata)
+}
+
+pub(crate) async fn acquire_queue_lock<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+) -> Result<(), PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    sqlx::query(ACQUIRE_QUEUE_LOCK)
+        .bind(*queue_name)
+        .execute(executor)
+        .await?;
+    Ok(())
 }

--- a/pgmq-rs/src/queue/transaction.rs
+++ b/pgmq-rs/src/queue/transaction.rs
@@ -1,0 +1,28 @@
+use crate::types::QueueName;
+use crate::PgmqError;
+
+/// Interface that provides methods for invoking PGMQ SQL functions that only make sense in the
+/// context of a transaction. For example, `pgmq.acquire_queue_lock` acquires a transaction-level
+/// advisory lock, so if it's not called inside an active transaction, it will have no effect (the
+/// lock will be released before the subsequent statements are executed).
+#[async_trait::async_trait]
+#[allow(private_bounds)]
+pub trait QueueTransaction: crate::queue::Queue {
+    /// Acquire a transaction-level advisory lock specific to the provided queue. Useful to prevent
+    /// race conditions when performing queue/table-level operations, such as creating an index
+    /// for the queue (e.g., with [`crate::queue::Queue::create_fifo_index`]).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(transaction: impl pgmq::queue::QueueTransaction) -> Result<(), pgmq::PgmqError> {
+    /// transaction.acquire_queue_lock("my_queue").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn acquire_queue_lock<'q, Q, QE>(self, queue_name: Q) -> Result<(), PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
+}

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -10,7 +10,7 @@
 #![cfg(feature = "queue-experimental")]
 
 use initialization::ConnDetails;
-use pgmq::queue::Queue;
+use pgmq::queue::{Queue, QueueTransaction};
 use pgmq::types::queue_name::QueueNameError;
 use pgmq::types::EMPTY_HEADERS;
 use pgmq::{Message, PgmqError};
@@ -1278,4 +1278,36 @@ async fn queue_metadata_partitioned(conn_details: ConnDetails, queue: impl Queue
     assert_eq!(QUEUE, metadata.queue_name);
     assert!(!metadata.is_unlogged, "Queue should not be unlogged");
     assert!(metadata.is_partitioned, "Queue should be partitioned");
+}
+
+#[pgmq_test_macro::queue_transaction_test]
+async fn acquire_queue_lock_invalid_queue_name(
+    conn_details: ConnDetails,
+    queue: impl QueueTransaction,
+) {
+    let result: Result<_, _> = queue.acquire_queue_lock("invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_transaction_test]
+async fn acquire_queue_lock(conn_details: ConnDetails, queue: impl QueueTransaction) {
+    use sqlx::Connection;
+
+    queue.acquire_queue_lock(QUEUE).await.unwrap();
+
+    let mut other_conn = initialization::sqlx_conn(&(conn_details.test_db_url.clone())).await;
+    let mut other_txn = other_conn.begin().await.unwrap();
+
+    let result =
+        tokio::time::timeout(Duration::from_secs(5), other_txn.acquire_queue_lock(QUEUE)).await;
+
+    assert!(
+        result.is_err(),
+        "Attempting to acquire the lock while it's held by a different transaction should timeout."
+    );
 }


### PR DESCRIPTION
This PR adds a `QueueTransaction` trait to represent PGMQ SQL functions that only make sense in the context of a transaction, such as `acquire_queue_lock`. This PR adds the `acquire_queue_lock` method and implements it for all the sql drivers we support (sqlx, diesel, rust-postgres). Similar to the implementation of `Queue`, `QueueTransaction` is implemented for various types using the new `impl_queue_transaction` macro.

This PR also

- Updates `PGMQueueExt` to use the `sqlx` implementation of `QueueTransaction#acquire_queue_lock`.
- Adds a new `queue_transaction_test` macro to use to help generate tests for the `QueueTransaction` trait.

Relates to https://github.com/pgmq/pgmq/issues/425