### PR TITLE
feat: Add `purge_queue` & `drop_queue` methods to `Queue` trait

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -13,7 +13,7 @@ use crate::util::{
     serialize_optional_list,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::{FromRow, Pool, Postgres, Row};
+use sqlx::{FromRow, Pool, Postgres};
 use std::ops::Deref;
 
 const DEFAULT_POLL_TIMEOUT_S: i32 = 5;
@@ -342,13 +342,8 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_queue_name(queue_name)?;
-        sqlx::query("SELECT pgmq.drop_queue(queue_name=>$1::text);")
-            .bind(queue_name)
-            .execute(executor)
-            .await?;
-
-        Ok(())
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::drop_queue(executor, queue_name).await
     }
 
     /// Drop an existing queue table.
@@ -362,12 +357,8 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<i64, PgmqError> {
-        check_queue_name(queue_name)?;
-        let purged = sqlx::query("SELECT * from pgmq.purge_queue(queue_name=>$1::text);")
-            .bind(queue_name)
-            .fetch_one(executor)
-            .await?;
-        Ok(purged.try_get("purge_queue")?)
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::purge_queue(executor, queue_name).await
     }
 
     /// Drop an existing queue table.

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -479,6 +479,32 @@ macro_rules! diesel_functions {
             $transform_result!(result)?;
             Ok(())
         }
+
+        async fn purge_queue<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<i64, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let message_id =
+                crate::queue::diesel::query::purge_queue_query(queue_name).get_result(executor);
+            let message_id = $transform_result!(message_id)?;
+            Ok(message_id)
+        }
+
+        async fn drop_queue<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result =
+                crate::queue::diesel::query::drop_queue_query(queue_name).execute(executor);
+            $transform_result!(result)?;
+            Ok(())
+        }
     };
 }
 

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -2,11 +2,12 @@
 use crate::queue::diesel::sql::{
     pgmq_acquire_queue_lock, pgmq_archive, pgmq_bind_topic, pgmq_convert_archive_partitioned,
     pgmq_create, pgmq_create_fifo_index, pgmq_create_fifo_indexes_all, pgmq_create_partitioned,
-    pgmq_create_unlogged, pgmq_delete, pgmq_disable_notify_insert, pgmq_enable_notify_insert,
-    pgmq_list_notify_insert_throttles, pgmq_list_queues, pgmq_list_topic_bindings,
-    pgmq_list_topic_bindings_all, pgmq_pop, pgmq_read, pgmq_read_grouped, pgmq_read_grouped_head,
-    pgmq_read_grouped_rr, pgmq_send, pgmq_send_batch, pgmq_send_batch_topic, pgmq_send_topic,
-    pgmq_set_vt, pgmq_unbind_topic, pgmq_update_notify_insert,
+    pgmq_create_unlogged, pgmq_delete, pgmq_disable_notify_insert, pgmq_drop_queue,
+    pgmq_enable_notify_insert, pgmq_list_notify_insert_throttles, pgmq_list_queues,
+    pgmq_list_topic_bindings, pgmq_list_topic_bindings_all, pgmq_pop, pgmq_purge_queue, pgmq_read,
+    pgmq_read_grouped, pgmq_read_grouped_head, pgmq_read_grouped_rr, pgmq_send, pgmq_send_batch,
+    pgmq_send_batch_topic, pgmq_send_topic, pgmq_set_vt, pgmq_unbind_topic,
+    pgmq_update_notify_insert,
 };
 use crate::types::{InsertNotificationThrottleInterval, QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
@@ -260,4 +261,16 @@ pub fn queue_metadata_query(queue_name: QueueName<'_>) -> _ {
 pub fn acquire_queue_lock_query(queue_name: QueueName<'_>) -> _ {
     let queue_name: &str = *queue_name;
     select(pgmq_acquire_queue_lock(queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn purge_queue_query(queue_name: QueueName<'_>) -> _ {
+    let queue_name: &str = *queue_name;
+    select(pgmq_purge_queue(queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn drop_queue_query(queue_name: QueueName<'_>) -> _ {
+    let queue_name: &str = *queue_name;
+    select(pgmq_drop_queue(queue_name))
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -263,4 +263,10 @@ extern "SQL" {
 
     #[sql_name = "pgmq.acquire_queue_lock"]
     fn pgmq_acquire_queue_lock(queue_name: Text);
+
+    #[sql_name = "pgmq.purge_queue"]
+    fn pgmq_purge_queue(queue_name: Text) -> BigInt;
+
+    #[sql_name = "pgmq.drop_queue"]
+    fn pgmq_drop_queue(queue_name: Text);
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -525,6 +525,24 @@ macro_rules! impl_queue {
                 let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 queue_metadata($transform_self!(self), queue_name).await
             }
+
+            async fn purge_queue<'q, Q, QE>(self, queue_name: Q) -> Result<i64, crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                purge_queue($transform_self!(self), queue_name).await
+            }
+
+            async fn drop_queue<'q, Q, QE>(self, queue_name: Q) -> Result<(), crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                drop_queue($transform_self!(self), queue_name).await
+            }
         }
     };
 }

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -898,4 +898,36 @@ pub trait Queue: crate::private::Sealed {
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Delete all messages in the provided queue.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// queue.purge_queue("my_queue").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn purge_queue<'q, Q, QE>(self, queue_name: Q) -> Result<i64, PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Drop the tables for the provided queue.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// queue.drop_queue("my_queue").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn drop_queue<'q, Q, QE>(self, queue_name: Q) -> Result<(), PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -623,6 +623,34 @@ macro_rules! rust_postgres_functions {
             $transform_result!(result)?;
             Ok(())
         }
+
+        async fn purge_queue<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<i64, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] =
+                [(&*queue_name, postgres_types::Type::TEXT)];
+            let row = executor.query_typed_one(crate::queue::sql::PURGE_QUEUE, &params);
+            let row = $transform_result!(row)?;
+            Ok(row.try_get(0)?)
+        }
+
+        async fn drop_queue<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] =
+                [(&*queue_name, postgres_types::Type::TEXT)];
+            let result = executor.execute_typed(crate::queue::sql::DROP_QUEUE, &params);
+            $transform_result!(result)?;
+            Ok(())
+        }
     };
 }
 pub(crate) use rust_postgres_functions;

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -99,3 +99,9 @@ pub(crate) const QUEUE_METADATA: &str =
 
 // language=PostgreSQL
 pub(crate) const ACQUIRE_QUEUE_LOCK: &str = "SELECT pgmq.acquire_queue_lock(queue_name=>$1::text)";
+
+// language=PostgreSQL
+pub(crate) const PURGE_QUEUE: &str = "SELECT * from pgmq.purge_queue(queue_name=>$1::text)";
+
+// language=PostgreSQL
+pub(crate) const DROP_QUEUE: &str = "SELECT pgmq.drop_queue(queue_name=>$1::text)";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -2,10 +2,10 @@ use crate::queue::macros::{identity_macro, impl_queue, impl_queue_transaction};
 use crate::queue::sql::{
     ACQUIRE_QUEUE_LOCK, ARCHIVE, BIND_TOPIC, CONVERT_ARCHIVE_PARTITIONED, CREATE,
     CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, CREATE_PARTITIONED, CREATE_UNLOGGED, DELETE,
-    DISABLE_NOTIFY_INSERT, ENABLE_NOTIFY_INSERT, LIST_NOTIFY_INSERT_THROTTLES, LIST_QUEUES,
-    LIST_TOPIC_BINDINGS, LIST_TOPIC_BINDINGS_ALL, POP, QUEUE_METADATA, READ, READ_GROUPED,
-    READ_GROUPED_HEAD, READ_GROUPED_RR, SEND, SEND_BATCH, SEND_BATCH_TOPIC, SEND_TOPIC, SET_VT,
-    UNBIND_TOPIC, UPDATE_NOTIFY_INSERT,
+    DISABLE_NOTIFY_INSERT, DROP_QUEUE, ENABLE_NOTIFY_INSERT, LIST_NOTIFY_INSERT_THROTTLES,
+    LIST_QUEUES, LIST_TOPIC_BINDINGS, LIST_TOPIC_BINDINGS_ALL, POP, PURGE_QUEUE, QUEUE_METADATA,
+    READ, READ_GROUPED, READ_GROUPED_HEAD, READ_GROUPED_RR, SEND, SEND_BATCH, SEND_BATCH_TOPIC,
+    SEND_TOPIC, SET_VT, UNBIND_TOPIC, UPDATE_NOTIFY_INSERT,
 };
 use crate::types::{
     InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, ListTopicBindingsRow,
@@ -534,6 +534,34 @@ where
     C: Executor<'c, Database = Postgres>,
 {
     sqlx::query(ACQUIRE_QUEUE_LOCK)
+        .bind(*queue_name)
+        .execute(executor)
+        .await?;
+    Ok(())
+}
+
+pub(crate) async fn purge_queue<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+) -> Result<i64, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let num_deleted = sqlx::query_scalar(PURGE_QUEUE)
+        .bind(*queue_name)
+        .fetch_one(executor)
+        .await?;
+    Ok(num_deleted)
+}
+
+pub(crate) async fn drop_queue<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+) -> Result<(), PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    sqlx::query(DROP_QUEUE)
         .bind(*queue_name)
         .execute(executor)
         .await?;

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -1280,6 +1280,63 @@ async fn queue_metadata_partitioned(conn_details: ConnDetails, queue: impl Queue
     assert!(metadata.is_partitioned, "Queue should be partitioned");
 }
 
+#[pgmq_test_macro::queue_test]
+async fn purge_queue_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<_, _> = queue.purge_queue("invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn purge_queue(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    queue.send(QUEUE, (), (), 0).await.unwrap();
+    let num_deleted = queue.purge_queue(QUEUE).await.unwrap();
+    assert_eq!(num_deleted, 1);
+
+    let msgs: Vec<Message<()>> = queue.read(QUEUE, 0, 1).await.unwrap();
+    assert!(msgs.is_empty());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn purge_queue_empty(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let num_deleted = queue.purge_queue(QUEUE).await.unwrap();
+    assert_eq!(num_deleted, 0);
+}
+
+#[pgmq_test_macro::queue_test]
+async fn drop_queue_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<_, _> = queue.drop_queue("invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn drop_queue(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    queue.drop_queue(QUEUE).await.unwrap();
+
+    let queue_metadata = queue.queue_metadata(QUEUE).await.unwrap();
+    assert!(queue_metadata.is_none());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn drop_queue_does_not_exist(conn_details: ConnDetails, queue: impl Queue) {
+    queue.drop_queue(QUEUE).await.unwrap();
+}
+
 #[pgmq_test_macro::queue_transaction_test]
 async fn acquire_queue_lock_invalid_queue_name(
     conn_details: ConnDetails,


### PR DESCRIPTION
This PR adds `purge_queue` and `drop_queue` methods to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres). This PR also updates the relevant methods in `PGMQueueExt` to use the sqlx implementation of `Queue`.

Relates to https://github.com/pgmq/pgmq/issues/425