### PR TITLE
feat: Add `metrics` & `metrics_all` methods to `Queue` trait

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1381,12 +1381,8 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<QueueMetrics, PgmqError> {
-        check_queue_name(queue_name)?;
-        let metrics: QueueMetrics = sqlx::query_as("SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages, scrape_time, queue_visible_length FROM pgmq.metrics(queue_name=>$1::text)")
-            .bind(queue_name)
-            .fetch_one(executor)
-            .await?;
-        Ok(metrics)
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::metrics(executor, queue_name).await
     }
 
     pub async fn metrics(&self, queue_name: &str) -> Result<QueueMetrics, PgmqError> {
@@ -1397,10 +1393,7 @@ impl PGMQueueExt {
         &self,
         executor: E,
     ) -> Result<Vec<QueueMetrics>, PgmqError> {
-        let metrics: Vec<QueueMetrics> = sqlx::query_as("SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages, scrape_time, queue_visible_length FROM pgmq.metrics_all()")
-            .fetch_all(executor)
-            .await?;
-        Ok(metrics)
+        crate::queue::sqlx::metrics_all(executor).await
     }
 
     pub async fn metrics_all(&self) -> Result<Vec<QueueMetrics>, PgmqError> {

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -505,6 +505,30 @@ macro_rules! diesel_functions {
             $transform_result!(result)?;
             Ok(())
         }
+
+        async fn metrics<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<crate::types::QueueMetrics, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result =
+                crate::queue::diesel::query::metrics_query(queue_name).get_result(executor);
+            let result = $transform_result!(result)?;
+            Ok(result)
+        }
+
+        async fn metrics_all<C>(
+            executor: &mut C,
+        ) -> Result<Vec<crate::types::QueueMetrics>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let rows = crate::queue::diesel::query::metrics_all_query().get_results(executor);
+            let rows = $transform_result!(rows)?;
+            Ok(rows)
+        }
     };
 }
 

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -4,10 +4,10 @@ use crate::queue::diesel::sql::{
     pgmq_create, pgmq_create_fifo_index, pgmq_create_fifo_indexes_all, pgmq_create_partitioned,
     pgmq_create_unlogged, pgmq_delete, pgmq_disable_notify_insert, pgmq_drop_queue,
     pgmq_enable_notify_insert, pgmq_list_notify_insert_throttles, pgmq_list_queues,
-    pgmq_list_topic_bindings, pgmq_list_topic_bindings_all, pgmq_pop, pgmq_purge_queue, pgmq_read,
-    pgmq_read_grouped, pgmq_read_grouped_head, pgmq_read_grouped_rr, pgmq_send, pgmq_send_batch,
-    pgmq_send_batch_topic, pgmq_send_topic, pgmq_set_vt, pgmq_unbind_topic,
-    pgmq_update_notify_insert,
+    pgmq_list_topic_bindings, pgmq_list_topic_bindings_all, pgmq_metrics, pgmq_metrics_all,
+    pgmq_pop, pgmq_purge_queue, pgmq_read, pgmq_read_grouped, pgmq_read_grouped_head,
+    pgmq_read_grouped_rr, pgmq_send, pgmq_send_batch, pgmq_send_batch_topic, pgmq_send_topic,
+    pgmq_set_vt, pgmq_unbind_topic, pgmq_update_notify_insert,
 };
 use crate::types::{InsertNotificationThrottleInterval, QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
@@ -273,4 +273,15 @@ pub fn purge_queue_query(queue_name: QueueName<'_>) -> _ {
 pub fn drop_queue_query(queue_name: QueueName<'_>) -> _ {
     let queue_name: &str = *queue_name;
     select(pgmq_drop_queue(queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn metrics_query(queue_name: QueueName<'_>) -> _ {
+    let queue_name: &str = *queue_name;
+    select(pgmq_metrics(queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn metrics_all_query() -> _ {
+    select(pgmq_metrics_all())
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -160,6 +160,47 @@ impl FromSqlRow<PgPGMQueueMeta, Pg> for crate::types::PGMQueueMeta {
     }
 }
 
+type PgQueueMetrics = diesel::sql_types::Record<(
+    // queue_name
+    Text,
+    // queue_length
+    BigInt,
+    // newest_msg_age_sec
+    Nullable<Integer>,
+    // oldest_msg_age_sec
+    Nullable<Integer>,
+    // total_messages
+    BigInt,
+    // scrape_time
+    Timestamptz,
+    // queue_visible_length
+    BigInt,
+)>;
+
+impl FromSql<PgQueueMetrics, Pg> for crate::types::QueueMetrics {
+    fn from_sql(bytes: PgValue) -> diesel::deserialize::Result<Self> {
+        let (
+            queue_name,
+            queue_length,
+            newest_msg_age_sec,
+            oldest_msg_age_sec,
+            total_messages,
+            scrape_time,
+            queue_visible_length,
+        ) = FromSql::<PgQueueMetrics, Pg>::from_sql(bytes)?;
+
+        Ok(Self {
+            queue_name,
+            queue_length,
+            newest_msg_age_sec,
+            oldest_msg_age_sec,
+            total_messages,
+            scrape_time,
+            queue_visible_length,
+        })
+    }
+}
+
 #[declare_sql_function]
 extern "SQL" {
     #[sql_name = "pgmq.create"]
@@ -269,4 +310,10 @@ extern "SQL" {
 
     #[sql_name = "pgmq.drop_queue"]
     fn pgmq_drop_queue(queue_name: Text);
+
+    #[sql_name = "pgmq.metrics"]
+    fn pgmq_metrics(queue_name: Text) -> PgQueueMetrics;
+
+    #[sql_name = "pgmq.metrics_all"]
+    fn pgmq_metrics_all() -> PgQueueMetrics;
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -543,6 +543,24 @@ macro_rules! impl_queue {
                 let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 drop_queue($transform_self!(self), queue_name).await
             }
+
+            async fn metrics<'q, Q, QE>(
+                self,
+                queue_name: Q,
+            ) -> Result<crate::types::QueueMetrics, crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                metrics($transform_self!(self), queue_name).await
+            }
+
+            async fn metrics_all(
+                self,
+            ) -> Result<Vec<crate::types::QueueMetrics>, crate::PgmqError> {
+                metrics_all($transform_self!(self)).await
+            }
         }
     };
 }

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -18,8 +18,8 @@ pub mod sqlx;
 mod transaction;
 
 use crate::types::{
-    InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, PGMQueueMeta, QueueName,
-    VisibilityTimeoutOffset,
+    InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, PGMQueueMeta, QueueMetrics,
+    QueueName, VisibilityTimeoutOffset,
 };
 use crate::{Message, PgmqError};
 
@@ -930,4 +930,35 @@ pub trait Queue: crate::private::Sealed {
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Get metrics for the provided queue.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// let metrics = queue.metrics("my_queue").await?;
+    /// println!("{metrics:?}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn metrics<'q, Q, QE>(self, queue_name: Q) -> Result<QueueMetrics, PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Get metrics for all queues.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// let metrics = queue.metrics_all().await?;
+    /// println!("{metrics:?}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn metrics_all(self) -> Result<Vec<QueueMetrics>, PgmqError>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -79,6 +79,22 @@ impl TryFrom<::tokio_postgres::Row> for crate::types::PGMQueueMeta {
     }
 }
 
+impl TryFrom<::tokio_postgres::Row> for crate::types::QueueMetrics {
+    type Error = ::tokio_postgres::Error;
+
+    fn try_from(value: ::tokio_postgres::Row) -> Result<Self, Self::Error> {
+        Ok(Self {
+            queue_name: value.try_get("queue_name")?,
+            queue_length: value.try_get("queue_length")?,
+            newest_msg_age_sec: value.try_get("newest_msg_age_sec")?,
+            oldest_msg_age_sec: value.try_get("oldest_msg_age_sec")?,
+            total_messages: value.try_get("total_messages")?,
+            scrape_time: value.try_get("scrape_time")?,
+            queue_visible_length: value.try_get("queue_visible_length")?,
+        })
+    }
+}
+
 type SqlParam<'a> = (&'a (dyn postgres_types::ToSql + Sync), postgres_types::Type);
 
 /// This macro defines all the functions required to implement [`crate::queue::Queue`] for both
@@ -650,6 +666,31 @@ macro_rules! rust_postgres_functions {
             let result = executor.execute_typed(crate::queue::sql::DROP_QUEUE, &params);
             $transform_result!(result)?;
             Ok(())
+        }
+
+        async fn metrics<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<crate::types::QueueMetrics, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] =
+                [(&*queue_name, postgres_types::Type::TEXT)];
+            let result = executor.query_typed_one(crate::queue::sql::METRICS, &params);
+            let result = $transform_result!(result)?;
+            Ok(crate::types::QueueMetrics::try_from(result)?)
+        }
+
+        async fn metrics_all<C>(
+            executor: $ref_type!(C),
+        ) -> Result<Vec<crate::types::QueueMetrics>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let rows = executor.query_typed(crate::queue::sql::METRICS_ALL, &[]);
+            let rows = $transform_result!(rows)?;
+            crate::queue::rust_postgres::convert_rows(rows)
         }
     };
 }

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -105,3 +105,9 @@ pub(crate) const PURGE_QUEUE: &str = "SELECT * from pgmq.purge_queue(queue_name=
 
 // language=PostgreSQL
 pub(crate) const DROP_QUEUE: &str = "SELECT pgmq.drop_queue(queue_name=>$1::text)";
+
+// language=PostgreSQL
+pub(crate) const METRICS: &str = "SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages, scrape_time, queue_visible_length FROM pgmq.metrics(queue_name=>$1::text)";
+
+// language=PostgreSQL
+pub(crate) const METRICS_ALL: &str = "SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages, scrape_time, queue_visible_length FROM pgmq.metrics_all()";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -3,13 +3,13 @@ use crate::queue::sql::{
     ACQUIRE_QUEUE_LOCK, ARCHIVE, BIND_TOPIC, CONVERT_ARCHIVE_PARTITIONED, CREATE,
     CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, CREATE_PARTITIONED, CREATE_UNLOGGED, DELETE,
     DISABLE_NOTIFY_INSERT, DROP_QUEUE, ENABLE_NOTIFY_INSERT, LIST_NOTIFY_INSERT_THROTTLES,
-    LIST_QUEUES, LIST_TOPIC_BINDINGS, LIST_TOPIC_BINDINGS_ALL, POP, PURGE_QUEUE, QUEUE_METADATA,
-    READ, READ_GROUPED, READ_GROUPED_HEAD, READ_GROUPED_RR, SEND, SEND_BATCH, SEND_BATCH_TOPIC,
-    SEND_TOPIC, SET_VT, UNBIND_TOPIC, UPDATE_NOTIFY_INSERT,
+    LIST_QUEUES, LIST_TOPIC_BINDINGS, LIST_TOPIC_BINDINGS_ALL, METRICS, METRICS_ALL, POP,
+    PURGE_QUEUE, QUEUE_METADATA, READ, READ_GROUPED, READ_GROUPED_HEAD, READ_GROUPED_RR, SEND,
+    SEND_BATCH, SEND_BATCH_TOPIC, SEND_TOPIC, SET_VT, UNBIND_TOPIC, UPDATE_NOTIFY_INSERT,
 };
 use crate::types::{
     InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, ListTopicBindingsRow,
-    PGMQueueMeta, QueueName, SendBatchTopicRow, VisibilityTimeoutOffset,
+    PGMQueueMeta, QueueMetrics, QueueName, SendBatchTopicRow, VisibilityTimeoutOffset,
 };
 use crate::{Message, PgmqError};
 use sqlx::{Executor, Postgres};
@@ -566,4 +566,26 @@ where
         .execute(executor)
         .await?;
     Ok(())
+}
+
+pub(crate) async fn metrics<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+) -> Result<QueueMetrics, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let metrics = sqlx::query_as(METRICS)
+        .bind(*queue_name)
+        .fetch_one(executor)
+        .await?;
+    Ok(metrics)
+}
+
+pub(crate) async fn metrics_all<'c, C>(executor: C) -> Result<Vec<QueueMetrics>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let metrics = sqlx::query_as(METRICS_ALL).fetch_all(executor).await?;
+    Ok(metrics)
 }

--- a/pgmq-rs/src/types/duration.rs
+++ b/pgmq-rs/src/types/duration.rs
@@ -10,14 +10,15 @@ use std::ops::Deref;
 /// correct [`Unit`].
 ///
 /// Provided values are mapped to an [`i32`] value because the PGMQ SQL functions expect integer
-/// values for their duration parameters, which corresponds to [`i32`] in Rust. Note how edge cases
-/// are handled:
+/// values for their duration parameters, which corresponds to [`i32`] in Rust.
 ///
-/// 1. Negative values do not make sense for any PGMQ use case, so the min value allowed for a
-///    [`Duration`] is `0` ([`Duration::MIN`]).
-/// 2. If converting to [`i32`] (e.g., from an [`i64`]) would result in an overflow, the value is
-///    capped at [`i32::MAX`] ([`Duration::MAX`]). The maximum [`i32`] value should be plenty
-///    large for virtually any PGMQ use case (68 years for seconds, 24 days for milliseconds).
+/// Note how overflows: If converting to [`i32`] (e.g., from an [`i64`]) would result in an overflow,
+/// the value is capped at [`i32::MAX`] ([`Duration::MAX`]) or [`i32::MIN`] ([`Duration::MIN`]). The
+/// maximum [`i32`] value should be plenty large for virtually any PGMQ use case (68 years for
+/// seconds, 24 days for milliseconds).
+///
+/// Negative values are allowed; however, negative values are not particularly useful for any
+/// PGMQ use case.
 ///
 /// Because the value contained in the [`Duration`] has already been converted to the correct units,
 /// it can be directly used in SQL queries by dereferencing the [`Duration`] (via the [`Deref`]
@@ -35,8 +36,8 @@ use std::ops::Deref;
 /// ## Convert from a negative `i32`
 /// ```
 /// # use pgmq::types::duration::{Duration, Milliseconds, Seconds};
-/// assert_eq!(0, *Duration::<Seconds>::from(-10i32));
-/// assert_eq!(0, *Duration::<Milliseconds>::from(-10i32));
+/// assert_eq!(-10, *Duration::<Seconds>::from(-10i32));
+/// assert_eq!(-10, *Duration::<Milliseconds>::from(-10i32));
 /// ```
 ///
 /// ## Convert from `u32`
@@ -70,7 +71,7 @@ use std::ops::Deref;
 /// ## Convert from `i64` -- capped min
 /// ```
 /// # use pgmq::types::duration::{Duration, Milliseconds, Seconds};
-/// assert_eq!(0i32, *Duration::<Seconds>::from(i64::MIN));
+/// assert_eq!(Duration::MIN, Duration::<Seconds>::from(i64::MIN));
 /// assert_eq!(Duration::MIN, Duration::<Milliseconds>::from(i64::MIN));
 /// ```
 ///
@@ -91,7 +92,7 @@ use std::ops::Deref;
 /// ## Convert from [`chrono::Duration`] -- capped min
 /// ```
 /// # use pgmq::types::duration::{Duration, Milliseconds, Seconds};
-/// assert_eq!(0i32, *Duration::<Seconds>::from(chrono::Duration::MIN));
+/// assert_eq!(Duration::MIN, Duration::<Seconds>::from(chrono::Duration::MIN));
 /// assert_eq!(Duration::MIN, Duration::<Milliseconds>::from(chrono::Duration::MIN));
 /// ```
 ///
@@ -132,7 +133,7 @@ impl Unit for Seconds {}
 
 impl<U: Unit> Duration<U> {
     /// The minimum allowed [`Duration`] value.
-    pub const MIN: Self = Self::new(0);
+    pub const MIN: Self = Self::new(i32::MIN);
 
     /// The maximum allowed [`Duration`] value.
     pub const MAX: Self = Self::new(i32::MAX);
@@ -185,39 +186,39 @@ impl<U: Unit> Deref for Duration<U> {
 
 impl<U: Unit> From<i32> for Duration<U> {
     fn from(value: i32) -> Self {
-        Self::new(std::cmp::max(value, 0))
+        Self::new(value)
     }
 }
 
 impl<U: Unit> From<u32> for Duration<U> {
     fn from(value: u32) -> Self {
-        Self::new(i32::try_from(value).unwrap_or(i32::MAX))
+        Self::new(i32::try_from(value).unwrap_or(*Self::MAX))
     }
 }
 
 impl<U: Unit> From<i64> for Duration<U> {
     fn from(value: i64) -> Self {
-        let value = i32::try_from(std::cmp::max(value, 0)).unwrap_or(i32::MAX);
+        let value = i32::try_from(std::cmp::max(value, *Self::MIN as i64)).unwrap_or(*Self::MAX);
         Self::new(value)
     }
 }
 
 impl<U: Unit> From<u64> for Duration<U> {
     fn from(value: u64) -> Self {
-        Self::new(i32::try_from(value).unwrap_or(i32::MAX))
+        Self::new(i32::try_from(value).unwrap_or(*Self::MAX))
     }
 }
 
 impl<U: Unit> From<i128> for Duration<U> {
     fn from(value: i128) -> Self {
-        let value = i32::try_from(std::cmp::max(value, 0)).unwrap_or(i32::MAX);
+        let value = i32::try_from(std::cmp::max(value, *Self::MIN as i128)).unwrap_or(*Self::MAX);
         Self::new(value)
     }
 }
 
 impl<U: Unit> From<u128> for Duration<U> {
     fn from(value: u128) -> Self {
-        Self::new(i32::try_from(value).unwrap_or(i32::MAX))
+        Self::new(i32::try_from(value).unwrap_or(*Self::MAX))
     }
 }
 

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -1337,6 +1337,59 @@ async fn drop_queue_does_not_exist(conn_details: ConnDetails, queue: impl Queue)
     queue.drop_queue(QUEUE).await.unwrap();
 }
 
+#[pgmq_test_macro::queue_test]
+async fn test_metrics(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let messages = [TestMessage::new(), TestMessage::new(), TestMessage::new()];
+    /*
+    `pgmq.send` and `pgmq.metrics` use different methods for fetching the current timestamp,
+    `clock_timestamp` vs `now`, which get the current timestamp and the time at which the current
+    transaction started, respectively. This causes the `QueueMetrics#queue_visible_length` field
+    to be `0` when this test runs inside a transaction. So, as a workaround, we set the `vt` to be
+    in the past, which allows the `vt` comparison to return the same number of items whether this
+    test runs inside a transaction or not.
+     */
+    queue
+        .send_batch(QUEUE, &messages, EMPTY_HEADERS, -10)
+        .await
+        .unwrap();
+
+    let _: Vec<Message<TestMessage>> = queue.read(QUEUE, 100, 1).await.unwrap();
+
+    let metrics = queue.metrics(QUEUE).await.unwrap();
+    assert_eq!(QUEUE, metrics.queue_name);
+    assert_eq!((messages.len() - 1) as i64, metrics.queue_visible_length);
+    assert_eq!(messages.len() as i64, metrics.queue_length);
+    assert_eq!(messages.len() as i64, metrics.total_messages);
+}
+
+#[pgmq_test_macro::queue_test]
+async fn test_metrics_all(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let messages = [TestMessage::new(), TestMessage::new(), TestMessage::new()];
+    // See the comment in `test_metrics` for why we set the `vt` to be in the past.
+    queue
+        .send_batch(QUEUE, &messages, EMPTY_HEADERS, -10)
+        .await
+        .unwrap();
+
+    let _: Vec<Message<TestMessage>> = queue.read(QUEUE, 100, 1).await.unwrap();
+
+    let metrics = queue
+        .metrics_all()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|metrics| metrics.queue_name == QUEUE)
+        .unwrap();
+    assert_eq!(QUEUE, metrics.queue_name);
+    assert_eq!((messages.len() - 1) as i64, metrics.queue_visible_length);
+    assert_eq!(messages.len() as i64, metrics.queue_length);
+    assert_eq!(messages.len() as i64, metrics.total_messages);
+}
+
 #[pgmq_test_macro::queue_transaction_test]
 async fn acquire_queue_lock_invalid_queue_name(
     conn_details: ConnDetails,


### PR DESCRIPTION
This PR adds `metrics` and `metrics_all` methods to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres).

This PR also
- Updates the relevant methods in `PGMQueueExt` to use the sqlx implementation of `Queue`.
- Updates our `Duration` type to allow negative values, which allows setting messages' `vt` value to the past. This is not particularly useful for any PGMQ use case, but it's necessary in order for the `metrics`/`metrics_all` tests to return the same values when they run inside of a transaction vs not.

Relates to https://github.com/pgmq/pgmq/issues/425