### PR TITLE
feat: Add "read with poll" methods to `Queue` trait

### DIFF
--- a/pgmq-rs/Cargo.lock
+++ b/pgmq-rs/Cargo.lock
@@ -1630,7 +1630,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgmq"
-version = "0.34.0-alpha.6"
+version = "0.34.0-alpha.7"
 dependencies = [
  "async-trait",
  "bb8",

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.34.0-alpha.6"
+version = "0.34.0-alpha.7"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1,8 +1,9 @@
 use crate::errors::PgmqError;
-use crate::queue::sql::READ;
-use crate::queue::sqlx::util::handle_read_batch_result;
+use crate::queue::sql::{
+    READ, READ_GROUPED_HEAD_WITH_POLL, READ_GROUPED_RR_WITH_POLL, READ_GROUPED_WITH_POLL,
+    READ_WITH_POLL,
+};
 use crate::queue::{Queue, QueueTransaction};
-use crate::types::queue_name::check_queue_name;
 use crate::types::{
     ListNotifyInsertThrottlesRow, ListTopicBindingsRow, Message, PGMQueueMeta, QueueMetrics,
     SendBatchTopicRow,
@@ -623,9 +624,14 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        let query = sqlx::query(READ);
-
-        Self::read_batch_common(query, queue_name, vt, qty, executor).await
+        crate::queue::sqlx::read_common(
+            executor,
+            sqlx::query(READ),
+            queue_name.try_into()?,
+            vt.into(),
+            qty,
+        )
+        .await
     }
 
     pub async fn read_batch<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
@@ -687,18 +693,8 @@ impl PGMQueueExt {
         poll_interval: Option<std::time::Duration>,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        let query = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_with_poll(
-                queue_name=>$1::text,
-                vt=>$2::integer,
-                qty=>$3::integer,
-                max_poll_seconds=>$4::integer,
-                poll_interval_ms=>$5::integer
-            )"#,
-        );
-
         Self::read_batch_with_poll_common(
-            query,
+            sqlx::query(READ_WITH_POLL),
             queue_name,
             vt,
             max_batch_size,
@@ -771,18 +767,8 @@ impl PGMQueueExt {
         poll_interval: Option<std::time::Duration>,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        let query = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_with_poll(
-                queue_name=>$1::text,
-                vt=>$2::integer,
-                qty=>$3::integer,
-                max_poll_seconds=>$4::integer,
-                poll_interval_ms=>$5::integer
-            )"#,
-        );
-
         Self::read_batch_with_poll_common(
-            query,
+            sqlx::query(READ_GROUPED_WITH_POLL),
             queue_name,
             vt,
             qty,
@@ -841,6 +827,54 @@ impl PGMQueueExt {
             .await
     }
 
+    pub async fn read_grouped_head_with_poll_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+        executor: E,
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
+        Self::read_batch_with_poll_common(
+            sqlx::query(READ_GROUPED_HEAD_WITH_POLL),
+            queue_name,
+            vt,
+            qty,
+            poll_timeout,
+            poll_interval,
+            executor,
+        )
+        .await
+    }
+
+    pub async fn read_grouped_head_with_poll<
+        T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
+        self.read_grouped_head_with_poll_with_cxn(
+            queue_name,
+            vt,
+            qty,
+            poll_timeout,
+            poll_interval,
+            &self.connection,
+        )
+        .await
+    }
+
     pub async fn read_grouped_rr_with_cxn<
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
@@ -881,18 +915,8 @@ impl PGMQueueExt {
         poll_interval: Option<std::time::Duration>,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        let query = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_rr_with_poll(
-                queue_name=>$1::text,
-                vt=>$2::integer,
-                qty=>$3::integer,
-                max_poll_seconds=>$4::integer,
-                poll_interval_ms=>$5::integer
-            )"#,
-        );
-
         Self::read_batch_with_poll_common(
-            query,
+            sqlx::query(READ_GROUPED_RR_WITH_POLL),
             queue_name,
             vt,
             qty,
@@ -925,31 +949,6 @@ impl PGMQueueExt {
         .await
     }
 
-    async fn read_batch_common<
-        'c,
-        'q,
-        E: sqlx::Executor<'c, Database = Postgres>,
-        T: for<'de> Deserialize<'de>,
-        H: for<'de> Deserialize<'de>,
-    >(
-        query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments>,
-        queue_name: &'q str,
-        vt: impl Into<VisibilityTimeoutOffset>,
-        qty: i32,
-        executor: E,
-    ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        check_queue_name(queue_name)?;
-        let vt: VisibilityTimeoutOffset = vt.into();
-        let rows = query
-            .bind(queue_name)
-            .bind(vt)
-            .bind(qty)
-            .fetch_all(executor)
-            .await?;
-
-        handle_read_batch_result(rows)
-    }
-
     async fn read_batch_with_poll_common<
         'c,
         'q,
@@ -965,21 +964,19 @@ impl PGMQueueExt {
         poll_interval: Option<std::time::Duration>,
         executor: E,
     ) -> Result<Vec<Message<T, H>>, PgmqError> {
-        check_queue_name(queue_name)?;
-        let vt: VisibilityTimeoutOffset = vt.into();
-        let poll_timeout_s = poll_timeout.map_or(DEFAULT_POLL_TIMEOUT_S, |t| t.as_secs() as i32);
-        let poll_interval_ms =
+        let poll_timeout = poll_timeout.map_or(DEFAULT_POLL_TIMEOUT_S, |t| t.as_secs() as i32);
+        let poll_interval =
             poll_interval.map_or(DEFAULT_POLL_INTERVAL_MS, |i| i.as_millis() as i32);
-        let rows = query
-            .bind(queue_name)
-            .bind(vt)
-            .bind(max_batch_size)
-            .bind(poll_timeout_s)
-            .bind(poll_interval_ms)
-            .fetch_all(executor)
-            .await?;
-
-        handle_read_batch_result(rows)
+        crate::queue::sqlx::read_with_poll_common(
+            executor,
+            query,
+            queue_name.try_into()?,
+            vt.into(),
+            max_batch_size,
+            poll_timeout.into(),
+            poll_interval.into(),
+        )
+        .await
     }
 
     pub async fn archive_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -529,6 +529,106 @@ macro_rules! diesel_functions {
             let rows = $transform_result!(rows)?;
             Ok(rows)
         }
+
+        async fn read_with_poll<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages = crate::queue::diesel::query::read_with_poll_query(
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
+        }
+
+        async fn read_grouped_with_poll<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages = crate::queue::diesel::query::read_grouped_with_poll_query(
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
+        }
+
+        async fn read_grouped_rr_with_poll<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages = crate::queue::diesel::query::read_grouped_rr_with_poll_query(
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
+        }
+
+        async fn read_grouped_head_with_poll<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages = crate::queue::diesel::query::read_grouped_head_with_poll_query(
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
+        }
     };
 }
 

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -6,10 +6,15 @@ use crate::queue::diesel::sql::{
     pgmq_enable_notify_insert, pgmq_list_notify_insert_throttles, pgmq_list_queues,
     pgmq_list_topic_bindings, pgmq_list_topic_bindings_all, pgmq_metrics, pgmq_metrics_all,
     pgmq_pop, pgmq_purge_queue, pgmq_read, pgmq_read_grouped, pgmq_read_grouped_head,
-    pgmq_read_grouped_rr, pgmq_send, pgmq_send_batch, pgmq_send_batch_topic, pgmq_send_topic,
-    pgmq_set_vt, pgmq_unbind_topic, pgmq_update_notify_insert,
+    pgmq_read_grouped_head_with_poll, pgmq_read_grouped_rr, pgmq_read_grouped_rr_with_poll,
+    pgmq_read_grouped_with_poll, pgmq_read_with_poll, pgmq_send, pgmq_send_batch,
+    pgmq_send_batch_topic, pgmq_send_topic, pgmq_set_vt, pgmq_unbind_topic,
+    pgmq_update_notify_insert,
 };
-use crate::types::{InsertNotificationThrottleInterval, QueueName, VisibilityTimeoutOffset};
+use crate::types::{
+    InsertNotificationThrottleInterval, PollInterval, PollTimeout, QueueName,
+    VisibilityTimeoutOffset,
+};
 use diesel::dsl::select;
 use diesel::{ExpressionMethods, QueryDsl};
 
@@ -284,4 +289,88 @@ pub fn metrics_query(queue_name: QueueName<'_>) -> _ {
 #[diesel::dsl::auto_type(no_type_alias)]
 pub fn metrics_all_query() -> _ {
     select(pgmq_metrics_all())
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn read_with_poll_query(
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    let poll_timeout: i32 = *poll_timeout;
+    let poll_interval: i32 = *poll_interval;
+    select(pgmq_read_with_poll(
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    ))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn read_grouped_with_poll_query(
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    let poll_timeout: i32 = *poll_timeout;
+    let poll_interval: i32 = *poll_interval;
+    select(pgmq_read_grouped_with_poll(
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    ))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn read_grouped_rr_with_poll_query(
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    let poll_timeout: i32 = *poll_timeout;
+    let poll_interval: i32 = *poll_interval;
+    select(pgmq_read_grouped_rr_with_poll(
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    ))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn read_grouped_head_with_poll_query(
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    let poll_timeout: i32 = *poll_timeout;
+    let poll_interval: i32 = *poll_interval;
+    select(pgmq_read_grouped_head_with_poll(
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    ))
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -320,4 +320,40 @@ extern "SQL" {
 
     #[sql_name = "pgmq.metrics_all"]
     fn pgmq_metrics_all() -> PgQueueMetrics;
+
+    #[sql_name = "pgmq.read_with_poll"]
+    fn pgmq_read_with_poll(
+        queue_name: Text,
+        vt: Integer,
+        qty: Integer,
+        max_poll_seconds: Integer,
+        poll_interval_ms: Integer,
+    ) -> PgMessage;
+
+    #[sql_name = "pgmq.read_grouped_with_poll"]
+    fn pgmq_read_grouped_with_poll(
+        queue_name: Text,
+        vt: Integer,
+        qty: Integer,
+        max_poll_seconds: Integer,
+        poll_interval_ms: Integer,
+    ) -> PgMessage;
+
+    #[sql_name = "pgmq.read_grouped_rr_with_poll"]
+    fn pgmq_read_grouped_rr_with_poll(
+        queue_name: Text,
+        vt: Integer,
+        qty: Integer,
+        max_poll_seconds: Integer,
+        poll_interval_ms: Integer,
+    ) -> PgMessage;
+
+    #[sql_name = "pgmq.read_grouped_head_with_poll"]
+    fn pgmq_read_grouped_head_with_poll(
+        queue_name: Text,
+        vt: Integer,
+        qty: Integer,
+        max_poll_seconds: Integer,
+        poll_interval_ms: Integer,
+    ) -> PgMessage;
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -561,6 +561,138 @@ macro_rules! impl_queue {
             ) -> Result<Vec<crate::types::QueueMetrics>, crate::PgmqError> {
                 metrics_all($transform_self!(self)).await
             }
+
+            async fn read_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+                poll_timeout: PT,
+                poll_interval: PI,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+                PT: Send + Into<crate::types::PollTimeout>,
+                PI: Send + Into<crate::types::PollInterval>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                let poll_timeout: crate::types::PollTimeout = poll_timeout.into();
+                let poll_interval: crate::types::PollInterval = poll_interval.into();
+                read_with_poll(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                    poll_timeout,
+                    poll_interval,
+                )
+                .await
+            }
+
+            async fn read_grouped_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+                poll_timeout: PT,
+                poll_interval: PI,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+                PT: Send + Into<crate::types::PollTimeout>,
+                PI: Send + Into<crate::types::PollInterval>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                let poll_timeout: crate::types::PollTimeout = poll_timeout.into();
+                let poll_interval: crate::types::PollInterval = poll_interval.into();
+                read_grouped_with_poll(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                    poll_timeout,
+                    poll_interval,
+                )
+                .await
+            }
+
+            async fn read_grouped_rr_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+                poll_timeout: PT,
+                poll_interval: PI,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+                PT: Send + Into<crate::types::PollTimeout>,
+                PI: Send + Into<crate::types::PollInterval>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                let poll_timeout: crate::types::PollTimeout = poll_timeout.into();
+                let poll_interval: crate::types::PollInterval = poll_interval.into();
+                read_grouped_rr_with_poll(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                    poll_timeout,
+                    poll_interval,
+                )
+                .await
+            }
+
+            async fn read_grouped_head_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+                poll_timeout: PT,
+                poll_interval: PI,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+                PT: Send + Into<crate::types::PollTimeout>,
+                PI: Send + Into<crate::types::PollInterval>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                let poll_timeout: crate::types::PollTimeout = poll_timeout.into();
+                let poll_interval: crate::types::PollInterval = poll_interval.into();
+                read_grouped_head_with_poll(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                    poll_timeout,
+                    poll_interval,
+                )
+                .await
+            }
         }
     };
 }

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -18,8 +18,8 @@ pub mod sqlx;
 mod transaction;
 
 use crate::types::{
-    InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, PGMQueueMeta, QueueMetrics,
-    QueueName, VisibilityTimeoutOffset,
+    InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, PGMQueueMeta, PollInterval,
+    PollTimeout, QueueMetrics, QueueName, VisibilityTimeoutOffset,
 };
 use crate::{Message, PgmqError};
 
@@ -961,4 +961,275 @@ pub trait Queue: crate::private::Sealed {
     /// # }
     /// ```
     async fn metrics_all(self) -> Result<Vec<QueueMetrics>, PgmqError>;
+
+    /// Read at most `quantity` messages from the queue with the provided `queue_name`, polling
+    /// the queue at the given `poll_interval`. If no messages are available, an empty [`Vec`] will
+    /// be returned after `poll_timeout` has elapsed.
+    ///
+    /// Invokes the `pgmq.read_with_poll` SQL function.
+    ///
+    /// Note: If the queue is empty, this method will hold the DB connection until the provided
+    /// `poll_timeout` elapses. Therefore, care should be taken when using this method. In
+    /// particular, it's not advised to use this method with a connection pool. Instead, consider
+    /// the following alternatives:
+    ///
+    /// 1. Use this method with a dedicated connection that can be safely held for `poll_timeout`
+    /// 2. Implement polling logic in your application code and call the normal [`Self::read`] method
+    /// 3. Listen for insert notifications. See [`Self::enable_notify_insert`] for more details
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read_with_poll("my_queue", 10, 1, 10, 250).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`) and set the `poll_timeout`/`poll_interval`.
+    /// let msgs: Vec<Message<MyMessage>> = queue.read_with_poll(
+    ///     "my_queue",
+    ///     Duration::from_secs(10),
+    ///     2,
+    ///     Duration::from_secs(10),
+    ///     Duration::from_millis(250)
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn read_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+        poll_timeout: PT,
+        poll_interval: PI,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>,
+        VT: Send + Into<VisibilityTimeoutOffset>,
+        PT: Send + Into<PollTimeout>,
+        PI: Send + Into<PollInterval>;
+
+    /// Reads messages with AWS SQS FIFO-style batch retrieval behavior. Returns at most `quantity`
+    /// messages from the same FIFO group from the queue with the provided `queue_name`, polling
+    /// the queue at the given `poll_interval`. If no messages are available, an empty [`Vec`] will
+    /// be returned after `poll_timeout` has elapsed.
+    ///
+    /// Invokes the `pgmq.read_grouped_with_poll` SQL function.
+    ///
+    /// Note: If the queue is empty, this method will hold the DB connection until the provided
+    /// `poll_timeout` elapses. Therefore, care should be taken when using this method. In
+    /// particular, it's not advised to use this method with a connection pool. Instead, consider
+    /// the following alternatives:
+    ///
+    /// 1. Use this method with a dedicated connection that can be safely held for `poll_timeout`
+    /// 2. Implement polling logic in your application code and call the normal [`Self::read_grouped`] method
+    /// 3. Listen for insert notifications. See [`Self::enable_notify_insert`] for more details
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read_grouped_with_poll("my_queue", 10, 1, 10, 250).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`) and set the `poll_timeout`/`poll_interval`.
+    /// let msgs: Vec<Message<MyMessage>> = queue.read_grouped_with_poll(
+    ///     "my_queue",
+    ///     Duration::from_secs(10),
+    ///     2,
+    ///     Duration::from_secs(10),
+    ///     Duration::from_millis(250)
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn read_grouped_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+        poll_timeout: PT,
+        poll_interval: PI,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>,
+        VT: Send + Into<VisibilityTimeoutOffset>,
+        PT: Send + Into<PollTimeout>,
+        PI: Send + Into<PollInterval>;
+
+    /// Read at most `quantity` messages from the queue with the provided `queue_name`, polling
+    /// the queue at the given `poll_interval`. Preserves FIFO order within groups and interleaves
+    /// across groups (layered round-robin). If no messages are available, an empty [`Vec`] will
+    /// be returned after `poll_timeout` has elapsed.
+    ///
+    /// Invokes the `pgmq.read_grouped_rr_with_poll` SQL function.
+    ///
+    /// Note: If the queue is empty, this method will hold the DB connection until the provided
+    /// `poll_timeout` elapses. Therefore, care should be taken when using this method. In
+    /// particular, it's not advised to use this method with a connection pool. Instead, consider
+    /// the following alternatives:
+    ///
+    /// 1. Use this method with a dedicated connection that can be safely held for `poll_timeout`
+    /// 2. Implement polling logic in your application code and call the normal [`Self::read_grouped_rr`] method
+    /// 3. Listen for insert notifications. See [`Self::enable_notify_insert`] for more details
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read_grouped_rr_with_poll("my_queue", 10, 1, 10, 250).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`) and set the `poll_timeout`/`poll_interval`.
+    /// let msgs: Vec<Message<MyMessage>> = queue.read_grouped_rr_with_poll(
+    ///     "my_queue",
+    ///     Duration::from_secs(10),
+    ///     2,
+    ///     Duration::from_secs(10),
+    ///     Duration::from_millis(250)
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn read_grouped_rr_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+        poll_timeout: PT,
+        poll_interval: PI,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>,
+        VT: Send + Into<VisibilityTimeoutOffset>,
+        PT: Send + Into<PollTimeout>,
+        PI: Send + Into<PollInterval>;
+
+    /// Read the head of at most `quantity` FIFO groups from the queue with the provided
+    /// `queue_name`. This supports horizontal scaling by processing groups in parallel while
+    /// ensuring message ordering is preserved per group. If no messages are available, an empty
+    /// [`Vec`] will be returned after `poll_timeout` has elapsed.
+    ///
+    /// Invokes the `pgmq.read_grouped_head_with_poll` SQL function.
+    ///
+    /// Note: If the queue is empty, this method will hold the DB connection until the provided
+    /// `poll_timeout` elapses. Therefore, care should be taken when using this method. In
+    /// particular, it's not advised to use this method with a connection pool. Instead, consider
+    /// the following alternatives:
+    ///
+    /// 1. Use this method with a dedicated connection that can be safely held for `poll_timeout`
+    /// 2. Implement polling logic in your application code and call the normal [`Self::read_grouped_head`] method
+    /// 3. Listen for insert notifications. See [`Self::enable_notify_insert`] for more details
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read_grouped_head_with_poll("my_queue", 10, 1, 10, 250).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`) and set the `poll_timeout`/`poll_interval`.
+    /// let msgs: Vec<Message<MyMessage>> = queue.read_grouped_head_with_poll(
+    ///     "my_queue",
+    ///     Duration::from_secs(10),
+    ///     2,
+    ///     Duration::from_secs(10),
+    ///     Duration::from_millis(250)
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn read_grouped_head_with_poll<'q, T, H, Q, QE, VT, PT, PI>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+        poll_timeout: PT,
+        poll_interval: PI,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>,
+        VT: Send + Into<VisibilityTimeoutOffset>,
+        PT: Send + Into<PollTimeout>,
+        PI: Send + Into<PollInterval>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -693,6 +693,132 @@ macro_rules! rust_postgres_functions {
             let rows = $transform_result!(rows)?;
             crate::queue::rust_postgres::convert_rows(rows)
         }
+
+        async fn read_with_poll<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            read_with_poll_common(
+                executor,
+                crate::queue::sql::READ_WITH_POLL,
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .await
+        }
+
+        async fn read_grouped_with_poll<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            read_with_poll_common(
+                executor,
+                crate::queue::sql::READ_GROUPED_WITH_POLL,
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .await
+        }
+
+        async fn read_grouped_rr_with_poll<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            read_with_poll_common(
+                executor,
+                crate::queue::sql::READ_GROUPED_RR_WITH_POLL,
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .await
+        }
+
+        async fn read_grouped_head_with_poll<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            read_with_poll_common(
+                executor,
+                crate::queue::sql::READ_GROUPED_HEAD_WITH_POLL,
+                queue_name,
+                visibility_timeout,
+                quantity,
+                poll_timeout,
+                poll_interval,
+            )
+            .await
+        }
+
+        async fn read_with_poll_common<C, T, H>(
+            executor: $ref_type!(C),
+            query: &'static str,
+            queue_name: crate::types::QueueName<'_>,
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+            quantity: i32,
+            poll_timeout: crate::types::PollTimeout,
+            poll_interval: crate::types::PollInterval,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&*queue_name, postgres_types::Type::TEXT),
+                (&*visibility_timeout, postgres_types::Type::INT4),
+                (&quantity, postgres_types::Type::INT4),
+                (&*poll_timeout, postgres_types::Type::INT4),
+                (&*poll_interval, postgres_types::Type::INT4),
+            ];
+            let rows = executor.query_typed(query, &params);
+            let rows = $transform_result!(rows)?;
+            crate::queue::rust_postgres::convert_rows(rows)
+        }
     };
 }
 pub(crate) use rust_postgres_functions;

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -111,3 +111,15 @@ pub(crate) const METRICS: &str = "SELECT queue_name, queue_length, newest_msg_ag
 
 // language=PostgreSQL
 pub(crate) const METRICS_ALL: &str = "SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages, scrape_time, queue_visible_length, default_partition_length FROM pgmq.metrics_all()";
+
+// language=PostgreSQL
+pub(crate) const READ_WITH_POLL: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_with_poll(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer, max_poll_seconds=>$4::integer, poll_interval_ms=>$5::integer)";
+
+// language=PostgreSQL
+pub(crate) const READ_GROUPED_WITH_POLL: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_with_poll(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer, max_poll_seconds=>$4::integer, poll_interval_ms=>$5::integer)";
+
+// language=PostgreSQL
+pub(crate) const READ_GROUPED_RR_WITH_POLL: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_rr_with_poll(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer, max_poll_seconds=>$4::integer, poll_interval_ms=>$5::integer)";
+
+// language=PostgreSQL
+pub(crate) const READ_GROUPED_HEAD_WITH_POLL: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_head_with_poll(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer, max_poll_seconds=>$4::integer, poll_interval_ms=>$5::integer)";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -4,12 +4,15 @@ use crate::queue::sql::{
     CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, CREATE_PARTITIONED, CREATE_UNLOGGED, DELETE,
     DISABLE_NOTIFY_INSERT, DROP_QUEUE, ENABLE_NOTIFY_INSERT, LIST_NOTIFY_INSERT_THROTTLES,
     LIST_QUEUES, LIST_TOPIC_BINDINGS, LIST_TOPIC_BINDINGS_ALL, METRICS, METRICS_ALL, POP,
-    PURGE_QUEUE, QUEUE_METADATA, READ, READ_GROUPED, READ_GROUPED_HEAD, READ_GROUPED_RR, SEND,
-    SEND_BATCH, SEND_BATCH_TOPIC, SEND_TOPIC, SET_VT, UNBIND_TOPIC, UPDATE_NOTIFY_INSERT,
+    PURGE_QUEUE, QUEUE_METADATA, READ, READ_GROUPED, READ_GROUPED_HEAD,
+    READ_GROUPED_HEAD_WITH_POLL, READ_GROUPED_RR, READ_GROUPED_RR_WITH_POLL,
+    READ_GROUPED_WITH_POLL, READ_WITH_POLL, SEND, SEND_BATCH, SEND_BATCH_TOPIC, SEND_TOPIC, SET_VT,
+    UNBIND_TOPIC, UPDATE_NOTIFY_INSERT,
 };
 use crate::types::{
     InsertNotificationThrottleInterval, ListNotifyInsertThrottlesRow, ListTopicBindingsRow,
-    PGMQueueMeta, QueueMetrics, QueueName, SendBatchTopicRow, VisibilityTimeoutOffset,
+    PGMQueueMeta, PollInterval, PollTimeout, QueueMetrics, QueueName, SendBatchTopicRow,
+    VisibilityTimeoutOffset,
 };
 use crate::{Message, PgmqError};
 use sqlx::{Executor, Postgres};
@@ -148,7 +151,14 @@ where
     T: for<'de> serde::Deserialize<'de>,
     H: for<'de> serde::Deserialize<'de>,
 {
-    read_common(executor, READ, queue_name, visibility_timeout, quantity).await
+    read_common(
+        executor,
+        sqlx::query(READ),
+        queue_name,
+        visibility_timeout,
+        quantity,
+    )
+    .await
 }
 
 pub(crate) async fn pop<'c, C, T, H>(
@@ -263,7 +273,7 @@ where
 {
     read_common(
         executor,
-        READ_GROUPED,
+        sqlx::query(READ_GROUPED),
         queue_name,
         visibility_timeout,
         quantity,
@@ -284,7 +294,7 @@ where
 {
     read_common(
         executor,
-        READ_GROUPED_HEAD,
+        sqlx::query(READ_GROUPED_HEAD),
         queue_name,
         visibility_timeout,
         quantity,
@@ -305,7 +315,7 @@ where
 {
     read_common(
         executor,
-        READ_GROUPED_RR,
+        sqlx::query(READ_GROUPED_RR),
         queue_name,
         visibility_timeout,
         quantity,
@@ -313,9 +323,9 @@ where
     .await
 }
 
-async fn read_common<'c, C, T, H>(
+pub(crate) async fn read_common<'c, 'q, C, T, H>(
     executor: C,
-    query: &'static str,
+    query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments>,
     queue_name: QueueName<'_>,
     visibility_timeout: VisibilityTimeoutOffset,
     quantity: i32,
@@ -325,7 +335,6 @@ where
     T: for<'de> serde::Deserialize<'de>,
     H: for<'de> serde::Deserialize<'de>,
 {
-    let query = sqlx::query(query);
     let rows = query
         .bind(*queue_name)
         .bind(visibility_timeout)
@@ -588,4 +597,130 @@ where
 {
     let metrics = sqlx::query_as(METRICS_ALL).fetch_all(executor).await?;
     Ok(metrics)
+}
+
+async fn read_with_poll<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    read_with_poll_common(
+        executor,
+        sqlx::query(READ_WITH_POLL),
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    )
+    .await
+}
+
+async fn read_grouped_with_poll<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    read_with_poll_common(
+        executor,
+        sqlx::query(READ_GROUPED_WITH_POLL),
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    )
+    .await
+}
+
+async fn read_grouped_rr_with_poll<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    read_with_poll_common(
+        executor,
+        sqlx::query(READ_GROUPED_RR_WITH_POLL),
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    )
+    .await
+}
+
+async fn read_grouped_head_with_poll<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    read_with_poll_common(
+        executor,
+        sqlx::query(READ_GROUPED_HEAD_WITH_POLL),
+        queue_name,
+        visibility_timeout,
+        quantity,
+        poll_timeout,
+        poll_interval,
+    )
+    .await
+}
+
+pub(crate) async fn read_with_poll_common<'c, 'q, C, T, H>(
+    executor: C,
+    query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments>,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+    poll_timeout: PollTimeout,
+    poll_interval: PollInterval,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    let rows = query
+        .bind(*queue_name)
+        .bind(visibility_timeout)
+        .bind(quantity)
+        .bind(poll_timeout)
+        .bind(poll_interval)
+        .fetch_all(executor)
+        .await?;
+
+    handle_read_batch_result(rows)
 }

--- a/pgmq-rs/src/types/mod.rs
+++ b/pgmq-rs/src/types/mod.rs
@@ -15,6 +15,14 @@ pub type VisibilityTimeoutOffset = duration::Duration<duration::Seconds>;
 /// e.g. in [`crate::queue::Queue::enable_notify_insert`] and [`crate::pg_ext::PGMQueueExt::enable_notify_insert`].
 pub type InsertNotificationThrottleInterval = duration::Duration<duration::Milliseconds>;
 
+/// Alias for the duration type expected for poll timeout parameters,
+/// e.g. in [`crate::queue::Queue::read_with_poll`] and [`crate::pg_ext::PGMQueueExt::read_with_poll`].
+pub type PollTimeout = duration::Duration<duration::Seconds>;
+
+/// Alias for the duration type expected for poll interval parameters,
+/// e.g. in [`crate::queue::Queue::read_with_poll`] and [`crate::pg_ext::PGMQueueExt::read_with_poll`].
+pub type PollInterval = duration::Duration<duration::Milliseconds>;
+
 /// Convenience value to provide for an optional `headers` parameter when no headers
 /// need to be sent. This is useful to avoid the somewhat cumbersome syntax required to specify
 /// the [`Option`] type when providing a [`None`] value.

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -1161,6 +1161,49 @@ async fn test_read_grouped_head_diff_groups() {
 }
 
 #[tokio::test]
+async fn test_read_grouped_head_with_poll() {
+    let test_queue = format!(
+        "test_read_grouped_head_with_poll_{}",
+        rand::rng().random_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let delay = 4;
+
+    let msg1 = MyMessage {
+        foo: "a".to_string(),
+        num: 1,
+    };
+    let headers1 = serde_json::json!({
+        "x-pgmq-group": msg1.num
+    });
+    let msg2 = MyMessage {
+        foo: "b".to_string(),
+        num: 1,
+    };
+    let headers2 = serde_json::json!({
+        "x-pgmq-group": msg2.num
+    });
+    let msgs = [msg1, msg2];
+    queue
+        .send_batch_with_delay_with_headers(&test_queue, &msgs, Some(&[headers1, headers2]), 0)
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<MyMessage>> = queue
+        .read_grouped_head_with_poll(
+            &test_queue,
+            100,
+            2,
+            Some(Duration::from_secs(delay + 1)),
+            Some(Duration::from_millis(100)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(1, read_msgs.len());
+}
+
+#[tokio::test]
 async fn test_read_grouped_with_poll() {
     let test_queue = format!(
         "test_read_grouped_with_poll_{}",

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -674,7 +674,7 @@ async fn read_grouped_custom_group(conn_details: ConnDetails, queue: impl Queue)
 }
 
 #[pgmq_test_macro::queue_test]
-async fn read_grouped_head_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+async fn read_group_head_invalid_queue(conn_details: ConnDetails, queue: impl Queue) {
     let result: Result<Vec<Message>, _> =
         queue.read_grouped_head("invalid-queue-name", 10, 1).await;
     assert_matches!(
@@ -1338,7 +1338,7 @@ async fn drop_queue_does_not_exist(conn_details: ConnDetails, queue: impl Queue)
 }
 
 #[pgmq_test_macro::queue_test]
-async fn test_metrics(conn_details: ConnDetails, queue: impl Queue) {
+async fn metrics(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
 
     let messages = [TestMessage::new(), TestMessage::new(), TestMessage::new()];
@@ -1365,7 +1365,7 @@ async fn test_metrics(conn_details: ConnDetails, queue: impl Queue) {
 }
 
 #[pgmq_test_macro::queue_test]
-async fn test_metrics_all(conn_details: ConnDetails, queue: impl Queue) {
+async fn metrics_all(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
 
     let messages = [TestMessage::new(), TestMessage::new(), TestMessage::new()];
@@ -1388,6 +1388,191 @@ async fn test_metrics_all(conn_details: ConnDetails, queue: impl Queue) {
     assert_eq!((messages.len() - 1) as i64, metrics.queue_visible_length);
     assert_eq!(messages.len() as i64, metrics.queue_length);
     assert_eq!(messages.len() as i64, metrics.total_messages);
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_with_poll_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message<TestMessage>>, _> = queue
+        .read_with_poll("invalid-queue-name", 10, 1, 1, 100)
+        .await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_with_poll_empty(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let msgs: Vec<Message<TestMessage>> = queue.read_with_poll(QUEUE, 10, 1, 1, 100).await.unwrap();
+    assert!(msgs.is_empty());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_with_poll(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let delay = 4;
+
+    let msgs = [TestMessage::new(), TestMessage::new(), TestMessage::new()];
+    queue
+        .send_batch(QUEUE, &msgs, EMPTY_HEADERS, delay)
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> = queue
+        .read_with_poll(QUEUE, 10, msgs.len() as i32, delay + 1, 100)
+        .await
+        .unwrap();
+    assert_eq!(msgs.len(), read_msgs.len());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_poll_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message<TestMessage>>, _> = queue
+        .read_grouped_with_poll("invalid-queue-name", 10, 1, 1, 100)
+        .await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_with_poll(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let delay = 4;
+
+    let msg1 = TestMessage {
+        a: "a".to_string(),
+        b: 1,
+    };
+    let headers1 = json!({
+        "x-pgmq-group": msg1.b
+    });
+    let msg2 = TestMessage {
+        a: "b".to_string(),
+        b: 2,
+    };
+    let headers2 = json!({
+        "x-pgmq-group": msg2.b
+    });
+    let msgs = [msg1, msg2];
+    queue
+        .send_batch(QUEUE, &msgs, Some(&[headers1, headers2]), delay)
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> = queue
+        .read_grouped_with_poll(QUEUE, 100, msgs.len() as i32, delay + 1, 100)
+        .await
+        .unwrap();
+    assert_eq!(msgs.len(), read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.b,
+        read_msgs.get(1).unwrap().message.b
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_rr_poll_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message<TestMessage>>, _> = queue
+        .read_grouped_rr_with_poll("invalid-queue-name", 10, 1, 1, 100)
+        .await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_rr_with_poll(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let delay = 4;
+
+    let msg1 = TestMessage {
+        a: "a".to_string(),
+        b: 1,
+    };
+    let headers1 = json!({
+        "x-pgmq-group": msg1.b
+    });
+    let msg2 = TestMessage {
+        a: "b".to_string(),
+        b: 2,
+    };
+    let headers2 = json!({
+        "x-pgmq-group": msg2.b
+    });
+    let msgs = [msg1, msg2];
+    queue
+        .send_batch(QUEUE, &msgs, Some(&[headers1, headers2]), delay)
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> = queue
+        .read_grouped_rr_with_poll(QUEUE, 100, msgs.len() as i32, delay + 1, 100)
+        .await
+        .unwrap();
+    assert_eq!(msgs.len(), read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.b,
+        read_msgs.get(1).unwrap().message.b
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_head_poll_invalid_queue(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message<TestMessage>>, _> = queue
+        .read_grouped_head_with_poll("invalid-queue-name", 10, 1, 1, 100)
+        .await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_grouped_head_with_poll(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+
+    let delay = 4;
+
+    let msg1 = TestMessage {
+        a: "a".to_string(),
+        b: 1,
+    };
+    let headers1 = json!({
+        "x-pgmq-group": msg1.b
+    });
+    let msg2 = TestMessage {
+        a: "b".to_string(),
+        b: 1,
+    };
+    let headers2 = json!({
+        "x-pgmq-group": msg2.b
+    });
+    let msgs = [msg1, msg2];
+    queue
+        .send_batch(QUEUE, &msgs, Some(&[headers1, headers2]), 0)
+        .await
+        .unwrap();
+
+    let read_msgs: Vec<Message<TestMessage>> = queue
+        .read_grouped_head_with_poll(QUEUE, 100, 2, delay + 1, 100)
+        .await
+        .unwrap();
+    assert_eq!(1, read_msgs.len());
 }
 
 #[pgmq_test_macro::queue_transaction_test]


### PR DESCRIPTION
This PR adds `read_with_poll`, `read_grouped_with_poll`, `read_grouped_rr_with_poll`, and `read_grouped_head_with_poll` to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres).

This PR also
- Adds `read_grouped_head_with_poll` to `PGMQueueExt`
- Updates the relevant methods in `PGMQueueExt` to use the sqlx implementation of `Queue`
- Bumps the crate pre-release version


Resolves https://github.com/pgmq/pgmq/issues/425
Resolves https://github.com/pgmq/pgmq/issues/544